### PR TITLE
new addConfigContents() call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 *.log
 artifacts
 coverage
+.*.swp

--- a/lib/index.js
+++ b/lib/index.js
@@ -187,6 +187,7 @@ function makeFakeYCB(dimensions, contents) {
 function Config(options) {
     this._options = options || {};
     this._dimensionsPath = this._options.dimensionsPath;
+    this._configContents = {};  // fullpath: contents
     this._configPaths = {};     // bundle: config: fullpath
     // cached data:
     this._configYCBs = {};  // fullpath: YCB object
@@ -210,8 +211,43 @@ Config.prototype = {};
  */
 Config.prototype.addConfig = function (bundleName, configName, fullPath, callback) {
     var self = this;
+    callback = callback || function() {};
     self._readConfigContents(fullPath, function (err, contents) {
-        // clear old contents (if any)
+        if (err) {
+            return callback(err);
+        }
+        self.addConfigContents(bundleName, configName, fullPath, contents, callback);
+    });
+};
+
+
+/**
+ * Registers a configuration file and its contents.
+ * @method addConfigContents
+ * @param {string} bundleName Name of the bundle to which this config file belongs.
+ * @param {string} configName Name of the config file.
+ * @param {string} fullPath Full filesystem path to the config file.
+ * @param {string|Object} contents The contents for the config file at the path.
+ * This will be parsed into an object (via JSON or YAML depending on the file extension)
+ * unless it is already an object.
+ * @param {Function} [callback] Called once the config has been added to the helper.
+ *   @param {Error|null} callback.err If an error occurred, then this parameter will
+ *   contain the error. If the operation succeeded, then `err` will be null.
+ *   @param {Object} callback.contents The contents of the config file, as a
+ *   JavaScript object.
+ */
+Config.prototype.addConfigContents = function (bundleName, configName, fullPath, contents, callback) {
+    var self = this;
+    callback = callback || function() {};
+    this._parseConfigContents(fullPath, contents, function(err, contents) {
+        if (err) {
+            return callback(err);
+        }
+
+        // register so that _readConfigContents() will use
+        self._configContents[fullPath] = contents;
+
+        // deregister old config (if any)
         self.deleteConfig(bundleName, configName, fullPath);
 
         if (!self._configPaths[bundleName]) {
@@ -236,9 +272,7 @@ Config.prototype.addConfig = function (bundleName, configName, fullPath, callbac
             }
         }
 
-        if (callback) {
-            return callback(null, contents);
-        }
+        callback(null, contents);
     });
 };
 
@@ -556,34 +590,52 @@ Config.prototype._readConfigContents = function (path, callback) {
         ext = libpath.extname(path),
         contents;
 
+    if (this._configContents[path]) {
+        callback(null, this._configContents[path]);
+        return;
+    }
+
     // really try to do things async as much as possible
     if ('.json' === ext || '.json5' === ext || '.yaml' === ext || '.yml' === ext) {
         libfs.readFile(path, 'utf8', function (err, contents) {
             if (err) {
                 return callback(err);
             }
-
-            try {
-                if ('.json' === ext) {
-                    contents = JSON.parse(contents);
-                } else if ('.json5' === ext) {
-                    contents = libjson5.parse(contents);
-                } else {
-                    contents = libyaml.parse(contents);
-                }
-                return callback(null, contents);
-            } catch (e) {
-                return callback(new Error(util.format(MESSAGES['parse error'], path, e.message)));
-            }
+            self._parseConfigContents(path, contents, function(err, contents) {
+                // TODO -- cache in _configContents?
+                return callback(err, contents);
+            });
         });
     } else {
         try {
             contents = require(path);
+            // TODO -- cache in _configContents?
             return callback(null, contents);
         } catch (e) {
             return callback(new Error(util.format(MESSAGES['parse error'], path, e.message)));
         }
     }
+};
+
+
+Config.prototype._parseConfigContents = function (path, contents, callback) {
+    var ext;
+    // Sometimes the contents are already parsed.
+    if ('object' !== typeof contents) {
+        ext = libpath.extname(path);
+        try {
+            if ('.json' === ext) {
+                contents = JSON.parse(contents);
+            } else if ('.json5' === ext) {
+                contents = libjson5.parse(contents);
+            } else {
+                contents = libyaml.parse(contents);
+            }
+        } catch (e) {
+            return callback(new Error(util.format(MESSAGES['parse error'], path, e.message)));
+        }
+    }
+    callback(null, contents);
 };
 
 

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -65,9 +65,8 @@ describe('config', function () {
             it('uses dimensionsBundle given to the constructor', function () {
                 var config = new Config({dimensionsBundle: 'foo'});
                 // we don't actually need to read the file
-                config._readConfigContents = function (path, callback) {
-                    return callback(null, 'contents');
-                };
+                config.addConfigContents('foo', 'dimensions', 'foo.json', '["contents"]');
+                config.addConfigContents('bar', 'dimensions', 'b.json', '["contents"]');
                 config.addConfig('foo', 'dimensions', 'foo.json');
                 config.addConfig('bar', 'dimensions', 'b.json');
                 expect(config._dimensionsPath).to.equal('foo.json');
@@ -76,9 +75,8 @@ describe('config', function () {
             it('uses shortest path', function () {
                 var config = new Config();
                 // we don't actually need to read the file
-                config._readConfigContents = function (path, callback) {
-                    return callback(null, 'contents');
-                };
+                config.addConfigContents('foo', 'dimensions', 'foo.json', '["contents"]');
+                config.addConfigContents('bar', 'dimensions', 'b.json', '["contents"]');
                 config.addConfig('foo', 'dimensions', 'foo.json');
                 config.addConfig('bar', 'dimensions', 'b.json');
                 expect(config._dimensionsPath).to.equal('b.json');
@@ -125,32 +123,44 @@ describe('config', function () {
         describe('addConfig()', function () {
 
             it('saves stats', function () {
-                var config,
-                    readCalls = 0;
-                config = new Config();
-                config._readConfigContents = function (path, callback) {
-                    readCalls += 1;
-                    callback(null, 'contents');
-                };
+                var config = new Config();
+                config.addConfigContents('foo', 'bar', 'x.json', '["contents"]');
                 config.addConfig('foo', 'bar', 'x.json');
                 expect(config._configPaths.foo.bar).to.equal('x.json');
-                expect(readCalls).to.equal(1);
             });
 
             it('updates an existing resource', function () {
-                var config,
-                    readCalls = 0;
-                config = new Config();
-                config._readConfigContents = function (path, callback) {
-                    readCalls += 1;
-                    callback(null, 'contents');
-                };
+                var config = new Config();
+                config.addConfigContents('foo', 'bar', 'x.js', '["contents"]');
+                config.addConfigContents('foo', 'bar', 'y.json', '["contents"]');
                 config.addConfig('foo', 'bar', 'x.js');
                 config.addConfig('foo', 'bar', 'y.json');
                 expect(config._configPaths.foo.bar).to.equal('y.json');
-                expect(readCalls).to.equal(2);
             });
 
+        });
+
+
+        describe('addConfigContents()', function () {
+            it('work with string content', function () {
+                var config;
+                config = new Config();
+                config.addConfigContents('foo', 'bar', 'x.json', '{"color":"orange"}');
+                config.read('foo', 'bar', {}, function(err, have) {
+                    expect(err).to.equal(null);
+                    expect(have.color).to.equal('orange');
+                });
+            });
+            it('work with object content', function () {
+                var config,
+                    object = {color: 'red'};
+                config = new Config();
+                config.addConfigContents('foo', 'bar', 'x.json', object);
+                config.read('foo', 'bar', {}, function(err, have) {
+                    expect(err).to.equal(null);
+                    expect(have.color).to.equal('red');
+                });
+            });
         });
 
 
@@ -496,8 +506,8 @@ describe('config', function () {
                     libpath.resolve(touchdown, 'configs/dimensions.json'),
                     function (err) {
                         config.read('simple', 'routes', {}, function (err, have) {
-                            console.log(err);
                             try {
+                                expect(err).to.equal(null);
                                 expect(have).to.be.an('array');
                                 expect(have[0]).to.be.an('object');
                                 expect(have[0].dimensions).to.be.an('array');


### PR DESCRIPTION
This is especially useful when the contents of the config doesn't actually
come from the file (or the contents of the file is modified before it's
registered in this system).

Fixes issue #6.
