### PR TITLE
Make _parseConfigContents synchronous

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -238,42 +238,40 @@ Config.prototype.addConfig = function (bundleName, configName, fullPath, callbac
  */
 Config.prototype.addConfigContents = function (bundleName, configName, fullPath, contents, callback) {
     var self = this;
-    callback = callback || function() {};
-    this._parseConfigContents(fullPath, contents, function(err, contents) {
-        if (err) {
-            return callback(err);
-        }
 
-        // register so that _readConfigContents() will use
-        self._configContents[fullPath] = contents;
+    contents = this._parseConfigContents(fullPath, contents);
 
-        // deregister old config (if any)
-        self.deleteConfig(bundleName, configName, fullPath);
+    // register so that _readConfigContents() will use
+    self._configContents[fullPath] = contents;
 
-        if (!self._configPaths[bundleName]) {
-            self._configPaths[bundleName] = {};
-        }
-        self._configPaths[bundleName][configName] = fullPath;
+    // deregister old config (if any)
+    self.deleteConfig(bundleName, configName, fullPath);
 
-        // keep path to dimensions file up-to-date
-        if ('dimensions' === configName && !self._options.dimensionsPath) {
-            if (self._options.dimensionsBundle) {
-                if (bundleName === self._options.dimensionsBundle) {
+    if (!self._configPaths[bundleName]) {
+        self._configPaths[bundleName] = {};
+    }
+    self._configPaths[bundleName][configName] = fullPath;
+
+    // keep path to dimensions file up-to-date
+    if ('dimensions' === configName && !self._options.dimensionsPath) {
+        if (self._options.dimensionsBundle) {
+            if (bundleName === self._options.dimensionsBundle) {
+                self._dimensionsPath = fullPath;
+            }
+        } else {
+            if (self._dimensionsPath) {
+                if (fullPath.length < self._dimensionsPath.length) {
                     self._dimensionsPath = fullPath;
                 }
             } else {
-                if (self._dimensionsPath) {
-                    if (fullPath.length < self._dimensionsPath.length) {
-                        self._dimensionsPath = fullPath;
-                    }
-                } else {
-                    self._dimensionsPath = fullPath;
-                }
+                self._dimensionsPath = fullPath;
             }
         }
+    }
 
+    if (callback) {
         callback(null, contents);
-    });
+    }
 };
 
 
@@ -619,7 +617,8 @@ Config.prototype._readConfigContents = function (path, callback) {
 
 
 Config.prototype._parseConfigContents = function (path, contents, callback) {
-    var ext;
+    var ext,
+        error;
     // Sometimes the contents are already parsed.
     if ('object' !== typeof contents) {
         ext = libpath.extname(path);
@@ -628,14 +627,22 @@ Config.prototype._parseConfigContents = function (path, contents, callback) {
                 contents = JSON.parse(contents);
             } else if ('.json5' === ext) {
                 contents = libjson5.parse(contents);
+            } else if ('.js' === ext) {
+                contents = require(path);
             } else {
                 contents = libyaml.parse(contents);
             }
         } catch (e) {
-            return callback(new Error(util.format(MESSAGES['parse error'], path, e.message)));
+            error = new Error(util.format(MESSAGES['parse error'], path, e.message));
+            if (callback) {
+                return callback(error);
+            } else {
+                return error;
+            }
         }
     }
-    callback(null, contents);
+
+    return callback ? callback(null, contents) : contents;
 };
 
 

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -161,6 +161,16 @@ describe('config', function () {
                     expect(have.color).to.equal('red');
                 });
             });
+            it('reads .js config files', function () {
+                var config,
+                    object = {color: 'red'};
+                config = new Config();
+                config.addConfigContents('foo', 'bar', 'x.js', object);
+                config.read('foo', 'bar', {}, function(err, have) {
+                    expect(err).to.equal(null);
+                    expect(have.color).to.equal('red');
+                });
+            });
         });
 
 
@@ -563,7 +573,7 @@ describe('config', function () {
                         libpath.resolve(mojito, 'application.json'),
                         function (err) {
                             if (err) { throw err; }
-                            config.read('modown-newsboxes', 
+                            config.read('modown-newsboxes',
                                         'application', {device: 'mobile'}, function (err, have) {
                                 try {
                                     expect(have).to.be.an('object');
@@ -952,7 +962,7 @@ describe('config', function () {
                                 next(err);
                             }
                         });
-                    }    
+                    }
                 );
             });
 


### PR DESCRIPTION
@drewfish

This makes `addConfigContents` and `_parseConfigContents` synchronous but maintains the callback if passed in.  All existing tests pass after this change.
