### PR TITLE
Move _readConfigContents callback out of try/catch

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -608,10 +608,11 @@ Config.prototype._readConfigContents = function (path, callback) {
         try {
             contents = require(path);
             // TODO -- cache in _configContents?
-            return callback(null, contents);
         } catch (e) {
             return callback(new Error(util.format(MESSAGES['parse error'], path, e.message)));
         }
+
+        return callback(null, contents);
     }
 };
 


### PR DESCRIPTION
@drewfish 

I found an issue where I had an error in my callback to `_readConfigContents` but because it was inside the try/catch, the error was being swallowed and the callback was getting called twice. Once in the try and again in the catch. This simple change is to move the return callback outside of the try.

More info on this issue here: http://joseoncode.com/2013/12/27/case-of-double-callbacks/
