### PR TITLE
Flexible package dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     },
     "homepage": "https://github.com/yahoo/ycb-config",
     "dependencies": {
-        "ycb": "~1.1.0",
+        "ycb": "^1.1.0",
         "json5": "~0.4.0",
         "yamljs": "~0.1.4",
         "lru-cache": "^2.3.1",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "homepage": "https://github.com/yahoo/ycb-config",
     "dependencies": {
         "ycb": "~1.1.0",
-        "json5": "0.2.0",
-        "yamljs": "0.1.4",
-        "lru-cache": "2.3.1",
+        "json5": "~0.4.0",
+        "yamljs": "~0.1.4",
+        "lru-cache": "^2.3.1",
         "deep-freeze": "~0.0.1"
     },
     "devDependencies": {


### PR DESCRIPTION
To prevent user downloading multiple version of our dependency,

The idea is if package is under ``1.0.0`` we use ``~`` and for stable package version (``>1.0.0``) we use ``^``
@caridy how do you think?