### PR TITLE
merge configs located at different file paths under one (bundleName,configName)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ var libfs       = require('fs'),
     libyaml     = require('yamljs'),
     libcache    = require('lru-cache'),
     deepFreeze  = require('deep-freeze'),
+    async       = require('async'),
 
     MESSAGES = {
         'unknown bundle': 'Unknown bundle "%s"',
@@ -213,6 +214,34 @@ Config.prototype.addConfig = function (bundleName, configName, fullPath, callbac
     var self = this;
     callback = callback || function() {};
     self._readConfigContents(fullPath, function (err, contents) {
+        if (err) {
+            return callback(err);
+        }
+        self.addConfigContents(bundleName, configName, fullPath, contents, callback);
+    });
+};
+
+
+/**
+ * Merges and registers multiple scattered configuration files under one (bundleName, configName).
+ * @method addScatteredConfigs
+ * @async
+ * @param {string} bundleName Name of the bundle to which this config group belongs.
+ * @param {string} configName Name of the config group.
+ * @param {string} fullPath Full filesystem path to the master config file. 
+ * @param {Array} scatteredConfigPaths array of full filesystem paths to the config files that will be merged into master config.
+ * @param {Function} [callback] Called once the config has been added to the helper.
+ *   @param {Error|null} callback.err If an error occurred, then this parameter will
+ *   contain the error. If the operation succeeded, then `err` will be null.
+ *   @param {Object} callback.contents The contents of the config file, as a
+ *   JavaScript object.
+ */
+Config.prototype.addScatteredConfigs = function (bundleName, configName, fullPath, scatteredConfigPaths, callback) {
+    var self = this;
+    callback = callback || function() {};
+    scatteredConfigPaths = scatteredConfigPaths || [];
+    var pathArray = [fullPath].concat(scatteredConfigPaths);
+    self._mergeConfigs(pathArray, function(err, contents){
         if (err) {
             return callback(err);
         }
@@ -644,6 +673,32 @@ Config.prototype._parseConfigContents = function (path, contents, callback) {
     }
 
     return callback ? callback(null, contents) : contents;
+};
+
+
+/**
+ * Merges contents from different files
+ * @private
+ * @method _mergeConfigs
+ * @param {Array} configFilePaths contains full paths to all config files to be merged.
+ * @param {Function} [callback] Called once the configs have been merged.
+ *   @param {Error|null} callback.err If an error occurred, then this parameter will
+ *   contain the error. If the operation succeeded, then `err` will be null.
+ *   @param {Object} callback.contents The contents of the merged config files, as a
+ *   JavaScript object.
+ */
+Config.prototype._mergeConfigs = function (configFilePaths, callback) {
+    var contents = [];
+    var self = this;
+    async.map(configFilePaths, self._readConfigContents.bind(self), function(err, results) {
+        if (err) {
+            return callback(err);
+        }
+        results.forEach(function(result) {
+            contents = contents.concat(result);
+        });
+        return callback(null, contents);
+    });
 };
 
 

--- a/package.json
+++ b/package.json
@@ -14,11 +14,12 @@
     },
     "homepage": "https://github.com/yahoo/ycb-config",
     "dependencies": {
-        "ycb": "^1.1.0",
+        "async": "~1.2.1",
+        "deep-freeze": "~0.0.1",
         "json5": "~0.4.0",
-        "yamljs": "~0.1.4",
         "lru-cache": "^2.3.1",
-        "deep-freeze": "~0.0.1"
+        "yamljs": "~0.1.4",
+        "ycb": "^1.1.0"
     },
     "devDependencies": {
         "chai": "*",

--- a/tests/fixtures/touchdown-simple/configs/bar.js
+++ b/tests/fixtures/touchdown-simple/configs/bar.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2013 Yahoo! Inc. All rights reserved.
+ * Copyrights licensed under the BSD License.
+ * See the accompanying LICENSE.txt file for terms.
+ */
+
+
+module.exports = [
+    {
+        settings: [ 'device:tv' ],
+        selector: 'tv'
+    },
+    {
+        settings: [ 'lang:en' ],
+        selector: 'en'
+    }
+];

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -141,6 +141,27 @@ describe('config', function () {
         });
 
 
+        describe('addScatteredConfigs()', function () {
+
+            it('saves stats', function () {
+                var config = new Config();
+                config.addConfigContents('foo', 'bar', 'x.json', '["contents"]');
+                config.addScatteredConfigs('foo', 'bar', 'x.json', []);
+                expect(config._configPaths.foo.bar).to.equal('x.json');
+            });
+
+            it('updates an existing resource', function () {
+                var config = new Config();
+                config.addConfigContents('foo', 'bar', 'x.js', '["contents"]');
+                config.addConfigContents('foo', 'bar', 'y.json', '["contents"]');
+                config.addScatteredConfigs('foo', 'bar', 'x.js', []);
+                config.addScatteredConfigs('foo', 'bar', 'y.json', []);
+                expect(config._configPaths.foo.bar).to.equal('y.json');
+            });
+
+        });
+
+
         describe('addConfigContents()', function () {
             it('work with string content', function () {
                 var config;
@@ -1061,6 +1082,43 @@ describe('config', function () {
                         );
                     }
                 );
+            });
+        });
+
+        
+        describe('_mergeConfigs()', function() {
+
+            it('merges the contents of specified config files', function(next) {
+                var config,
+                    pathArray;
+                config = new Config();
+                pathArray = [libpath.resolve(touchdown, 'configs/foo.js'), libpath.resolve(touchdown, 'configs/bar.js') ];
+                config._mergeConfigs(pathArray, function(err, have) {
+                    var want = [
+                        { settings: [ 'master' ], TODO: 'TODO' },
+                        { settings: [ 'device:mobile' ], selector: 'mobile' },
+                        { settings: [ 'device:tv' ], selector: 'tv' },
+                        { settings: [ 'lang:en' ], selector: 'en' }
+                    ];
+                    try {
+                        compareObjects(have, want);
+                        next();
+                    } catch (err) {
+                        next(err);
+                    }
+                });
+            });
+
+            it('fails if there is an error reading/parsing any of the files', function (next) {
+                var config,
+                    pathArray;
+                config = new Config();
+                pathArray = [libpath.resolve(touchdown, 'configs/foo.js'), libpath.resolve(mojito, 'broken.j')];
+                config._mergeConfigs(pathArray, function (err, config) {
+                    expect(err).to.have.property('message');
+                    expect(err).to.have.property('stack');
+                    next();
+                });
             });
         });
     });


### PR DESCRIPTION
Will allow registering multiple config files under one (bundleName, configName). 

This can useful for splitting up configs. Consider a scenario where an app uses a reusable component that gets it's configs from ycb-config. To make the component actually reusable, the default configs can be a part of the component, and the app that actually uses the component can specify its own configs that will be merged with the component's configs.