### PR TITLE
fix: convert to es5 for node6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
+    - "12"
     - "10"
     - "8"

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -5,39 +5,37 @@
 /**
  * Entry class used as map values and intrusive linked list nodes.
  */
-class Entry {
-    constructor (key, value, setAt, expiresAt, groupId) {
-        this.next = null;
-        this.prev = null;
-        this.key = key;
-        this.value = value;
-        this.setAt = setAt;
-        this.expiresAt = expiresAt;
-        this.groupId = groupId;
-    }
+function Entry(key, value, setAt, expiresAt, groupId) {
+    this.next = null;
+    this.prev = null;
+    this.key = key;
+    this.value = value;
+    this.setAt = setAt;
+    this.expiresAt = expiresAt;
+    this.groupId = groupId;
 }
 
 /**
  * LRU cache.
  * Supported options are {max: int} which will set the max capacity of the cache.
  */
-class ConfigCache {
-    constructor(options) {
-        options = options || {};
-        this.max = options.max;
-        if(!Number.isInteger(options.max) || options.max < 0) {
-            console.log('WARNING: no valid cache capacity given, defaulting to 100. %s', JSON.stringify(options));
-            this.max = 100;
-        }
-        if(this.max === 0) {
-            this.get = this.set = this.getTimeAware = this.setTimeAware = function(){};
-        }
-        this.size = 0;
-        this.map = new Map(); //key -> Entry
-        this.youngest = null;
-        this.oldest = null;
+function ConfigCache(options) {
+    options = options || {};
+    this.max = options.max;
+    if(!Number.isInteger(options.max) || options.max < 0) {
+        console.log('WARNING: no valid cache capacity given, defaulting to 100. %s', JSON.stringify(options));
+        this.max = 100;
     }
+    if(this.max === 0) {
+        this.get = this.set = this.getTimeAware = this.setTimeAware = function(){};
+    }
+    this.size = 0;
+    this.map = new Map(); //key -> Entry
+    this.youngest = null;
+    this.oldest = null;
+}
 
+ConfigCache.prototype = {
     /**
      * Set a cache entry.
      * @param {string} key Key mapping to this value.
@@ -46,7 +44,7 @@ class ConfigCache {
      */
     set(key, value, groupId) {
         this.setTimeAware(key, value, 0, 0, groupId);
-    }
+    },
 
     /**
      * Set a time aware cache entry.
@@ -90,7 +88,7 @@ class ConfigCache {
         this.youngest.prev = entry;
         this.youngest = entry;
         this.size++;
-    }
+    },
 
     /**
      * Get value from the cache. Will return undefined if entry is not in cache or is stale.
@@ -108,7 +106,7 @@ class ConfigCache {
             return entry.value;
         }
         return undefined;
-    }
+    },
 
     /**
      * Get value from the cache with time awareness. Will return undefined if entry is not in cache or is stale.
@@ -127,7 +125,7 @@ class ConfigCache {
             return entry.value;
         }
         return undefined;
-    }
+    },
 
     /**
      * Move entry to the head of the list and set as youngest.
@@ -151,6 +149,6 @@ class ConfigCache {
         entry.next = this.youngest;
         this.youngest = entry;
     }
-}
+};
 
 module.exports = ConfigCache;


### PR DESCRIPTION
Need to convert to es5 to avoid breaking older apps.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
