### PR TITLE
Promise usage

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -662,7 +662,7 @@ Config.prototype._mergeBaseContext = function (context) {
 
 Config.prototype.addConfigPromise = promisify(Config.prototype.addConfig);
 Config.prototype.addConfigContentsPromise = promisify(
-  Config.prototype.addConfigContentsPromise
+  Config.prototype.addConfigContents
 );
 Config.prototype.readPromise = promisify(Config.prototype.read);
 Config.prototype.readNoMergePromise = promisify(Config.prototype.readNoMerge);

--- a/lib/index.js
+++ b/lib/index.js
@@ -659,6 +659,17 @@ Config.prototype._mergeBaseContext = function (context) {
     return mix(clone(context), this._options.baseContext);
 };
 
+Config.prototype.readPromise = function(bundleName, configName, context) {
+  var self = this;
+  return new Promise(function(resolve, reject) {//jshint ignore:line
+     self.read(bundleName, configName, context, function(err, result) {
+      if (err) {
+        reject(err);
+      }
+      resolve(result);
+    });
+  });
+};
 
 module.exports = Config;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ var libfs       = require('fs'),
     libyaml     = require('yamljs'),
     libcache    = require('lru-cache'),
     deepFreeze  = require('deep-freeze'),
+    promisify   = require('util').promisify,
 
     MESSAGES = {
         'unknown bundle': 'Unknown bundle "%s"',
@@ -659,17 +660,15 @@ Config.prototype._mergeBaseContext = function (context) {
     return mix(clone(context), this._options.baseContext);
 };
 
-Config.prototype.readPromise = function(bundleName, configName, context) {
-  var self = this;
-  return new Promise(function(resolve, reject) {//jshint ignore:line
-     self.read(bundleName, configName, context, function(err, result) {
-      if (err) {
-        reject(err);
-      }
-      resolve(result);
-    });
-  });
-};
+Config.prototype.addConfigPromise = promisify(Config.prototype.addConfig);
+Config.prototype.addConfigContentsPromise = promisify(
+  Config.prototype.addConfigContentsPromise
+);
+Config.prototype.readPromise = promisify(Config.prototype.read);
+Config.prototype.readNoMergePromise = promisify(Config.prototype.readNoMerge);
+Config.prototype.readDimensionsPromise = promisify(
+  Config.prototype.readDimensions
+);
 
 module.exports = Config;
 

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -1063,218 +1063,481 @@ describe('config', function () {
                 );
             });
         });
+
+
         /* jshint ignore:start */
-        describe("readPromises usage", function() {
-            it("fails on unknown bundle", function(next) {
-              var config = new Config();
-              config.readPromise("foo", "bar", {}).catch(err => {
-                expect(err.message).to.equal('Unknown bundle "foo"');
-                next();
-              });
-            });
-
-            it("fails on unknown config", function(next) {
-              var config = new Config();
-              config.addConfig(
-                "modown-newsboxes",
-                "application",
-                libpath.resolve(mojito, "application.json"),
-                function(err) {
-                  config
-                    .readPromise("modown-newsboxes", "foo", {})
-                    .catch(err =>{
-                      expect(err.message).to.equal(
-                        'Unknown config "foo" in bundle "modown-newsboxes"'
-                      )
-                    next();}
-                    )
-                }
-              );
-            });
-
-            it("reads non-contextualized .json config files", function(next) {
-              var config = new Config();
-              config.addConfig(
-                "simple",
-                "routes",
-                libpath.resolve(touchdown, "configs/dimensions.json"),
-                function(err) {
-                  config
-                    .readPromise("simple", "routes", {})
-                    .then(have => {
-                      expect(have).to.be.an("array");
-                      expect(have[0]).to.be.an("object");
-                      expect(have[0].dimensions).to.be.an("array");
-                      next();
-                    })
-                }
-              );
-            });
-
-            it("reads contextualized .js config files", function(next) {
-              var config = new Config();
-              config.addConfig(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json"),
-                function(err) {
-                  if (err) {
-                    throw err;
-                  }
-                  config.addConfig(
-                    "simple",
-                    "foo",
-                    libpath.resolve(touchdown, "configs/foo.js"),
-                    function(err) {
-                      if (err) {
-                        throw err;
-                      }
-                      config
-                        .readPromise("simple", "foo", { device: "mobile" })
-                        .then(have => {
-                          expect(have).to.be.an("object");
-                          expect(have.TODO).to.equal("TODO");
-                          expect(have.selector).to.equal("mobile");
-                          next()
-                        })
-                    }
-                  );
-                }
-              );
-            });
-
-            it("reads contextualized .json config files", function(next) {
-              var config = new Config();
-              config.addConfig(
-                "modown",
-                "dimensions",
-                libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
-                function(err) {
-                  if (err) {
-                    throw err;
-                  }
-                  config.addConfig(
-                    "modown-newsboxes",
-                    "application",
-                    libpath.resolve(mojito, "application.json"),
-                    function(err) {
-                      if (err) {
-                        throw err;
-                      }
-                      config
-                        .readPromise("modown-newsboxes", "application", {
-                          device: "mobile"
-                        })
-                        .then(have => {
-                          expect(have).to.be.an("object");
-                          expect(have.TODO).to.equal("TODO");
-                          expect(have.selector).to.equal("mobile");
-                          next();
-                        })
-                    }
-                  );
-                }
-              );
-            });
-
-            it("applies baseContext", function(next) {
-              var config = new Config({
-                baseContext: {
-                  device: "mobile"
-                }
-              });
-              config.addConfig(
-                "modown",
-                "dimensions",
-                libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
-                function() {
-                  config.addConfig(
-                    "modown-newsboxes",
-                    "application",
-                    libpath.resolve(mojito, "application.json"),
-                    function(err) {
-                      if (err) {
-                        throw err;
-                      }
-                      config
-                        .readPromise("modown-newsboxes", "application", {})
-                        .then(have => {
-                          expect(have).to.be.an("object");
-                          expect(have.TODO).to.equal("TODO");
-                          expect(have.selector).to.equal("mobile");
-                          next();
-                        })
-                    }
-                  );
-                }
-              );
-            });
-
-            it("survives a bad context", function(next) {
-              var config, context;
-              context = { device: "torture" };
-              config = new Config();
-              config.addConfig(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json"),
-                function(err) {
-                  if (err) {
-                    throw err;
-                  }
-                  config.addConfig(
-                    "simple",
-                    "foo",
-                    libpath.resolve(touchdown, "configs/foo.js"),
-                    function(err) {
-                      if (err) {
-                        throw err;
-                      }
-                      config
-                        .readPromise("simple", "foo", context)
-                        .then(have =>{
-                          expect(have.selector).to.be.an("undefined")
-                        next()}
-                        )
-                    }
-                  );
-                }
-              );
-            });
-
-            it("freezes the config object if the `safeMode` option is passed", function(next) {
-              var config = new Config({
-                safeMode: true
-              });
-              config.addConfig(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json"),
-                function(err) {
-                  if (err) {
-                    throw err;
-                  }
-                  config.addConfig(
-                    "simple",
-                    "foo",
-                    libpath.resolve(touchdown, "configs/foo.js"),
-                    function(err) {
-                      if (err) {
-                        throw err;
-                      }
-                      config
-                        .readPromise("simple", "foo", { device: "mobile" })
-                        .then(have => {
-                          expect(have).to.be.an("object");
-                          expect(have.TODO).to.equal("TODO");
-                          next()
-                        })
-                    }
-                  );
-                }
-              );
+        describe("readPromises()", function() {
+          it("fails on unknown bundle", function(next) {
+            var config = new Config();
+            config.readPromise("foo", "bar", {}).catch(err => {
+              expect(err.message).to.equal('Unknown bundle "foo"');
+              next();
             });
           });
+
+          it("fails on unknown config", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "modown-newsboxes",
+              "application",
+              libpath.resolve(mojito, "application.json"),
+              function(err) {
+                config.readPromise("modown-newsboxes", "foo", {}).catch(err => {
+                  expect(err.message).to.equal(
+                    'Unknown config "foo" in bundle "modown-newsboxes"'
+                  );
+                  next();
+                });
+              }
+            );
+          });
+
+          it("reads non-contextualized .json config files", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "simple",
+              "routes",
+              libpath.resolve(touchdown, "configs/dimensions.json"),
+              function(err) {
+                config.readPromise("simple", "routes", {}).then(have => {
+                  expect(have).to.be.an("array");
+                  expect(have[0]).to.be.an("object");
+                  expect(have[0].dimensions).to.be.an("array");
+                  next();
+                });
+              }
+            );
+          });
+
+          it("reads contextualized .js config files", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "simple",
+              "dimensions",
+              libpath.resolve(touchdown, "configs/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.addConfig(
+                  "simple",
+                  "foo",
+                  libpath.resolve(touchdown, "configs/foo.js"),
+                  function(err) {
+                    if (err) {
+                      throw err;
+                    }
+                    config
+                      .readPromise("simple", "foo", { device: "mobile" })
+                      .then(have => {
+                        expect(have).to.be.an("object");
+                        expect(have.TODO).to.equal("TODO");
+                        expect(have.selector).to.equal("mobile");
+                        next();
+                      });
+                  }
+                );
+              }
+            );
+          });
+
+          it("reads contextualized .json config files", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "modown",
+              "dimensions",
+              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.addConfig(
+                  "modown-newsboxes",
+                  "application",
+                  libpath.resolve(mojito, "application.json"),
+                  function(err) {
+                    if (err) {
+                      throw err;
+                    }
+                    config
+                      .readPromise("modown-newsboxes", "application", {
+                        device: "mobile"
+                      })
+                      .then(have => {
+                        expect(have).to.be.an("object");
+                        expect(have.TODO).to.equal("TODO");
+                        expect(have.selector).to.equal("mobile");
+                        next();
+                      });
+                  }
+                );
+              }
+            );
+          });
+
+          it("applies baseContext", function(next) {
+            var config = new Config({
+              baseContext: {
+                device: "mobile"
+              }
+            });
+            config.addConfig(
+              "modown",
+              "dimensions",
+              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
+              function() {
+                config.addConfig(
+                  "modown-newsboxes",
+                  "application",
+                  libpath.resolve(mojito, "application.json"),
+                  function(err) {
+                    if (err) {
+                      throw err;
+                    }
+                    config
+                      .readPromise("modown-newsboxes", "application", {})
+                      .then(have => {
+                        expect(have).to.be.an("object");
+                        expect(have.TODO).to.equal("TODO");
+                        expect(have.selector).to.equal("mobile");
+                        next();
+                      });
+                  }
+                );
+              }
+            );
+          });
+
+          it("survives a bad context", function(next) {
+            var config, context;
+            context = { device: "torture" };
+            config = new Config();
+            config.addConfig(
+              "simple",
+              "dimensions",
+              libpath.resolve(touchdown, "configs/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.addConfig(
+                  "simple",
+                  "foo",
+                  libpath.resolve(touchdown, "configs/foo.js"),
+                  function(err) {
+                    if (err) {
+                      throw err;
+                    }
+                    config.readPromise("simple", "foo", context).then(have => {
+                      expect(have.selector).to.be.an("undefined");
+                      next();
+                    });
+                  }
+                );
+              }
+            );
+          });
+
+          it("freezes the config object if the `safeMode` option is passed", function(next) {
+            var config = new Config({
+              safeMode: true
+            });
+            config.addConfig(
+              "simple",
+              "dimensions",
+              libpath.resolve(touchdown, "configs/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.addConfig(
+                  "simple",
+                  "foo",
+                  libpath.resolve(touchdown, "configs/foo.js"),
+                  function(err) {
+                    if (err) {
+                      throw err;
+                    }
+                    config
+                      .readPromise("simple", "foo", { device: "mobile" })
+                      .then(have => {
+                        expect(have).to.be.an("object");
+                        expect(have.TODO).to.equal("TODO");
+                        next();
+                      });
+                  }
+                );
+              }
+            );
+          });
+        });
+
+
+        describe("readNoMerge()", function() {
+          it("fails on unknown bundle", function(next) {
+            var config = new Config();
+            config.readNoMergePromise("foo", "bar", {}).catch(err => {
+              expect(err.message).to.equal('Unknown bundle "foo"');
+              next();
+            });
+          });
+
+          it("fails on unknown config", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "modown-newsboxes",
+              "application",
+              libpath.resolve(mojito, "application.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config
+                  .readNoMergePromise("modown-newsboxes", "foo", {})
+                  .catch(err => {
+                    expect(err.message).to.equal(
+                      'Unknown config "foo" in bundle "modown-newsboxes"'
+                    );
+                    next();
+                  });
+              }
+            );
+          });
+
+          it("reads non-contextualized .json config files", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "simple",
+              "routes",
+              libpath.resolve(touchdown, "configs/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.readNoMergePromise("simple", "routes", {}).then(have => {
+                  expect(have).to.be.an("array");
+                  expect(have[0]).to.be.an("array");
+                  expect(have[0][0]).to.be.an("object");
+                  expect(have[0][0].dimensions).to.be.an("array");
+                  next();
+                });
+              }
+            );
+          });
+
+          it("reads contextualized .js config files", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "simple",
+              "dimensions",
+              libpath.resolve(touchdown, "configs/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.addConfig(
+                  "simple",
+                  "foo",
+                  libpath.resolve(touchdown, "configs/foo.js"),
+                  function(err) {
+                    config
+                      .readNoMergePromise("simple", "foo", { device: "mobile" })
+                      .then(have => {
+                        expect(have).to.be.an("array");
+                        expect(have[0]).to.be.an("object");
+                        expect(have[0].TODO).to.equal("TODO");
+                        expect(have[1]).to.be.an("object");
+                        expect(have[1].selector).to.equal("mobile");
+                        next();
+                      });
+                  }
+                );
+              }
+            );
+          });
+
+          it("reads contextualized .json config files", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "modown",
+              "dimensions",
+              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.addConfig(
+                  "modown-newsboxes",
+                  "application",
+                  libpath.resolve(mojito, "application.json"),
+                  function(err) {
+                    if (err) {
+                      throw err;
+                    }
+                    config
+                      .readNoMergePromise("modown-newsboxes", "application", {
+                        device: "mobile"
+                      })
+                      .then(have => {
+                        expect(have).to.be.an("array");
+                        expect(have[0]).to.be.an("object");
+                        expect(have[0].TODO).to.equal("TODO");
+                        expect(have[1]).to.be.an("object");
+                        expect(have[1].selector).to.equal("mobile");
+                        next();
+                      });
+                  }
+                );
+              }
+            );
+          });
+
+          it("applies baseContext", function(next) {
+            var config = new Config({
+              baseContext: {
+                device: "mobile"
+              }
+            });
+            config.addConfig(
+              "modown",
+              "dimensions",
+              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.addConfig(
+                  "modown-newsboxes",
+                  "application",
+                  libpath.resolve(mojito, "application.json"),
+                  function(err) {
+                    if (err) {
+                      throw err;
+                    }
+                    config
+                      .readNoMergePromise("modown-newsboxes", "application", {})
+                      .then(have => {
+                        expect(have).to.be.an("array");
+                        expect(have[0]).to.be.an("object");
+                        expect(have[0].TODO).to.equal("TODO");
+                        expect(have[1]).to.be.an("object");
+                        expect(have[1].selector).to.equal("mobile");
+                        next();
+                      });
+                  }
+                );
+              }
+            );
+          });
+
+          it("survives a bad context", function(next) {
+            var config, context;
+            context = { device: "torture" };
+            config = new Config();
+            config.addConfig(
+              "simple",
+              "dimensions",
+              libpath.resolve(touchdown, "configs/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.addConfig(
+                  "simple",
+                  "foo",
+                  libpath.resolve(touchdown, "configs/foo.js"),
+                  function(err) {
+                    if (err) {
+                      throw err;
+                    }
+                    config
+                      .readNoMergePromise("simple", "foo", context)
+                      .then(have => {
+                        expect(have.selector).to.be.an("undefined");
+                        next();
+                      });
+                  }
+                );
+              }
+            );
+          });
+
+          it("freezes the config object if the `safeMode` option is passed", function(next) {
+            var config = new Config({
+              safeMode: true
+            });
+            config.addConfig(
+              "simple",
+              "dimensions",
+              libpath.resolve(touchdown, "configs/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.addConfig(
+                  "simple",
+                  "foo",
+                  libpath.resolve(touchdown, "configs/foo.js"),
+                  function(err) {
+                    if (err) {
+                      throw err;
+                    }
+                    config
+                      .readNoMergePromise("simple", "foo", { device: "mobile" })
+                      .then(have => {
+                        expect(have).to.be.an("array");
+                        expect(have[0]).to.be.an("object");
+                        expect(have[0].TODO).to.equal("TODO");
+                        try {
+                          have[0].TODO = "DONE";
+                        } catch (err) {
+                          expect(err.message).to.equal(
+                            "Cannot assign to read only property 'TODO' of object '#<Object>'"
+                          );
+                          next();
+                        }
+                      });
+                  }
+                );
+              }
+            );
+          });
+        });
+
+
+        describe("readDimensionsPromise()", function() {
+          it("mojito-newsboxes", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "modown",
+              "dimensions",
+              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
+              function(err, data) {
+                config.readDimensionsPromise().then(dims => {
+                  expect(dims).to.be.an("array");
+                  expect(dims[0]).to.have.property("runtime");
+                  next();
+                });
+              }
+            );
+          });
+
+          it("touchdown-simple", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "simple",
+              "dimensions",
+              libpath.resolve(touchdown, "configs/dimensions.json"),
+              function(err, data) {
+                config.readDimensionsPromise().then(dims => {
+                  expect(dims).to.be.an("array");
+                  expect(dims[0]).to.have.property("ynet");
+                  next();
+                });
+              }
+            );
+          });
+        });
         /* jshint ignore:end */
     });
 });

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -1067,12 +1067,10 @@ describe('config', function () {
         describe("readPromises usage", function() {
             it("fails on unknown bundle", function(next) {
               var config = new Config();
-              config
-                .readPromise("foo", "bar", {})
-                .catch(err =>
-                  expect(err.message).to.equal('Unknown bundle "foo"')
-                )
-                .finally(next);
+              config.readPromise("foo", "bar", {}).catch(err => {
+                expect(err.message).to.equal('Unknown bundle "foo"');
+                next();
+              });
             });
 
             it("fails on unknown config", function(next) {
@@ -1084,12 +1082,12 @@ describe('config', function () {
                 function(err) {
                   config
                     .readPromise("modown-newsboxes", "foo", {})
-                    .catch(err =>
+                    .catch(err =>{
                       expect(err.message).to.equal(
                         'Unknown config "foo" in bundle "modown-newsboxes"'
                       )
+                    next();}
                     )
-                    .finally(next);
                 }
               );
             });
@@ -1107,8 +1105,8 @@ describe('config', function () {
                       expect(have).to.be.an("array");
                       expect(have[0]).to.be.an("object");
                       expect(have[0].dimensions).to.be.an("array");
+                      next();
                     })
-                    .finally(next);
                 }
               );
             });
@@ -1137,8 +1135,8 @@ describe('config', function () {
                           expect(have).to.be.an("object");
                           expect(have.TODO).to.equal("TODO");
                           expect(have.selector).to.equal("mobile");
+                          next()
                         })
-                        .finally(next);
                     }
                   );
                 }
@@ -1171,8 +1169,8 @@ describe('config', function () {
                           expect(have).to.be.an("object");
                           expect(have.TODO).to.equal("TODO");
                           expect(have.selector).to.equal("mobile");
+                          next();
                         })
-                        .finally(next);
                     }
                   );
                 }
@@ -1204,8 +1202,8 @@ describe('config', function () {
                           expect(have).to.be.an("object");
                           expect(have.TODO).to.equal("TODO");
                           expect(have.selector).to.equal("mobile");
+                          next();
                         })
-                        .then(next);
                     }
                   );
                 }
@@ -1234,10 +1232,10 @@ describe('config', function () {
                       }
                       config
                         .readPromise("simple", "foo", context)
-                        .then(have =>
+                        .then(have =>{
                           expect(have.selector).to.be.an("undefined")
+                        next()}
                         )
-                        .finally(next);
                     }
                   );
                 }
@@ -1269,8 +1267,8 @@ describe('config', function () {
                         .then(have => {
                           expect(have).to.be.an("object");
                           expect(have.TODO).to.equal("TODO");
+                          next()
                         })
-                        .finally(next);
                     }
                   );
                 }

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -1066,440 +1066,413 @@ describe('config', function () {
 
 
         /* jshint ignore:start */
-        describe("readPromises()", function() {
-          it("fails on unknown bundle", function(next) {
+        describe('readPromises()', function() {
+          it('fails on unknown bundle', function(next) {
             var config = new Config();
-            config.readPromise("foo", "bar", {}).catch(err => {
+            config.readPromise('foo', 'bar', {}).catch(err => {
               expect(err.message).to.equal('Unknown bundle "foo"');
               next();
             });
           });
 
-          it("fails on unknown config", function(next) {
+          it('fails on unknown config', function(next) {
             var config = new Config();
             config
               .addConfigPromise(
-                "modown-newsboxes",
-                "application",
-                libpath.resolve(mojito, "application.json")
+                'modown-newsboxes',
+                'application',
+                libpath.resolve(mojito, 'application.json')
+              )
+              .then(() => config.readPromise('modown-newsboxes', 'foo', {}))
+              .catch(err => {
+                expect(err.message).to.equal(
+                  'Unknown config "foo" in bundle "modown-newsboxes"'
+                );
+                next();
+              });
+          });
+
+          it('reads non-contextualized .json config files', function(next) {
+            var config = new Config();
+            config
+              .addConfigPromise(
+                'simple',
+                'routes',
+                libpath.resolve(touchdown, 'configs/dimensions.json')
+              )
+              .then(() => config.readPromise('simple', 'routes', {}))
+              .then(have => {
+                expect(have).to.be.an('array');
+                expect(have[0]).to.be.an('object');
+                expect(have[0].dimensions).to.be.an('array');
+                next();
+              });
+          });
+
+          it('reads contextualized .js config files', function(next) {
+            var config = new Config();
+            config
+              .addConfigPromise(
+                'simple',
+                'dimensions',
+                libpath.resolve(touchdown, 'configs/dimensions.json')
               )
               .then(() =>
-                config.readPromise("modown-newsboxes", "foo", {}).catch(err => {
+                config.addConfigPromise(
+                  'simple',
+                  'foo',
+                  libpath.resolve(touchdown, 'configs/foo.js')
+                )
+              )
+              .then(() =>
+                config.readPromise('simple', 'foo', { device: 'mobile' })
+              )
+              .then(have => {
+                expect(have).to.be.an('object');
+                expect(have.TODO).to.equal('TODO');
+                expect(have.selector).to.equal('mobile');
+                next();
+              });
+          });
+
+          it('reads contextualized .json config files', function(next) {
+            var config = new Config();
+            config
+              .addConfigPromise(
+                'modown',
+                'dimensions',
+                libpath.resolve(mojito, 'node_modules/modown/dimensions.json')
+              )
+              .then(() =>
+                config.addConfigPromise(
+                  'modown-newsboxes',
+                  'application',
+                  libpath.resolve(mojito, 'application.json')
+                )
+              )
+              .then(() =>
+                config.readPromise('modown-newsboxes', 'application', {
+                  device: 'mobile'
+                })
+              )
+              .then(have => {
+                expect(have).to.be.an('object');
+                expect(have.TODO).to.equal('TODO');
+                expect(have.selector).to.equal('mobile');
+                next();
+              });
+          });
+
+          it('applies baseContext', function(next) {
+            var config = new Config({
+              baseContext: {
+                device: 'mobile'
+              }
+            });
+            config
+              .addConfigPromise(
+                'modown',
+                'dimensions',
+                libpath.resolve(mojito, 'node_modules/modown/dimensions.json')
+              )
+              .then(() =>
+                config.addConfigPromise(
+                  'modown-newsboxes',
+                  'application',
+                  libpath.resolve(mojito, 'application.json')
+                )
+              )
+              .then(() =>
+                config.readPromise('modown-newsboxes', 'application', {})
+              )
+              .then(have => {
+                expect(have).to.be.an('object');
+                expect(have.TODO).to.equal('TODO');
+                expect(have.selector).to.equal('mobile');
+                next();
+              });
+          });
+
+          it('survives a bad context', function(next) {
+            var config, context;
+            context = { device: 'torture' };
+            config = new Config();
+            config
+              .addConfigPromise(
+                'simple',
+                'dimensions',
+                libpath.resolve(touchdown, 'configs/dimensions.json')
+              )
+              .then(() =>
+                config.addConfigPromise(
+                  'simple',
+                  'foo',
+                  libpath.resolve(touchdown, 'configs/foo.js')
+                )
+              )
+              .then(() =>
+                config.readPromise('simple', 'foo', context).then(have => {
+                  expect(have.selector).to.be.an('undefined');
+                  next();
+                })
+              );
+          });
+
+          it('freezes the config object if the `safeMode` option is passed', function(next) {
+            var config = new Config({
+              safeMode: true
+            });
+            config
+              .addConfigPromise(
+                'simple',
+                'dimensions',
+                libpath.resolve(touchdown, 'configs/dimensions.json')
+              )
+              .then(() =>
+                config.addConfigPromise(
+                  'simple',
+                  'foo',
+                  libpath.resolve(touchdown, 'configs/foo.js')
+                )
+              )
+              .then(() =>
+                config.readPromise('simple', 'foo', { device: 'mobile' })
+              )
+              .then(have => {
+                expect(have).to.be.an('object');
+                expect(have.TODO).to.equal('TODO');
+                next();
+              });
+          });
+        });
+
+        describe('readNoMerge()', function() {
+          it('fails on unknown bundle', function(next) {
+            var config = new Config();
+            config.readNoMergePromise('foo', 'bar', {}).catch(err => {
+              expect(err.message).to.equal('Unknown bundle "foo"');
+              next();
+            });
+          });
+
+          it('fails on unknown config', function(next) {
+            var config = new Config();
+            config
+              .addConfigPromise(
+                'modown-newsboxes',
+                'application',
+                libpath.resolve(mojito, 'application.json')
+              )
+              .then(() =>
+                config.readNoMergePromise('modown-newsboxes', 'foo', {})
+              )
+              .catch(err => {
+                expect(err.message).to.equal(
+                  'Unknown config "foo" in bundle "modown-newsboxes"'
+                );
+                next();
+              });
+          });
+
+          it('reads non-contextualized .json config files', function(next) {
+            var config = new Config();
+            config
+              .addConfigPromise(
+                'simple',
+                'routes',
+                libpath.resolve(touchdown, 'configs/dimensions.json')
+              )
+              .then(() => config.readNoMergePromise('simple', 'routes', {}))
+              .then(have => {
+                expect(have).to.be.an('array');
+                expect(have[0]).to.be.an('array');
+                expect(have[0][0]).to.be.an('object');
+                expect(have[0][0].dimensions).to.be.an('array');
+                next();
+              });
+          });
+
+          it('reads contextualized .js config files', function(next) {
+            var config = new Config();
+            config
+              .addConfigPromise(
+                'simple',
+                'dimensions',
+                libpath.resolve(touchdown, 'configs/dimensions.json')
+              )
+              .then(() =>
+                config.addConfigPromise(
+                  'simple',
+                  'foo',
+                  libpath.resolve(touchdown, 'configs/foo.js')
+                )
+              )
+              .then(() =>
+                config.readNoMergePromise('simple', 'foo', { device: 'mobile' })
+              )
+              .then(have => {
+                expect(have).to.be.an('array');
+                expect(have[0]).to.be.an('object');
+                expect(have[0].TODO).to.equal('TODO');
+                expect(have[1]).to.be.an('object');
+                expect(have[1].selector).to.equal('mobile');
+                next();
+              });
+          });
+
+          it('reads contextualized .json config files', function(next) {
+            var config = new Config();
+            config
+              .addConfigPromise(
+                'modown',
+                'dimensions',
+                libpath.resolve(mojito, 'node_modules/modown/dimensions.json')
+              )
+              .then(() =>
+                config.addConfigPromise(
+                  'modown-newsboxes',
+                  'application',
+                  libpath.resolve(mojito, 'application.json')
+                )
+              )
+              .then(() =>
+                config.readNoMergePromise('modown-newsboxes', 'application', {
+                  device: 'mobile'
+                })
+              )
+              .then(have => {
+                expect(have).to.be.an('array');
+                expect(have[0]).to.be.an('object');
+                expect(have[0].TODO).to.equal('TODO');
+                expect(have[1]).to.be.an('object');
+                expect(have[1].selector).to.equal('mobile');
+                next();
+              });
+          });
+
+          it('applies baseContext', function(next) {
+            var config = new Config({
+              baseContext: {
+                device: 'mobile'
+              }
+            });
+            config
+              .addConfigPromise(
+                'modown',
+                'dimensions',
+                libpath.resolve(mojito, 'node_modules/modown/dimensions.json')
+              )
+              .then(() =>
+                config.addConfigPromise(
+                  'modown-newsboxes',
+                  'application',
+                  libpath.resolve(mojito, 'application.json')
+                )
+              )
+              .then(() =>
+                config.readNoMergePromise('modown-newsboxes', 'application', {})
+              )
+              .then(have => {
+                expect(have).to.be.an('array');
+                expect(have[0]).to.be.an('object');
+                expect(have[0].TODO).to.equal('TODO');
+                expect(have[1]).to.be.an('object');
+                expect(have[1].selector).to.equal('mobile');
+                next();
+              });
+          });
+
+          it('survives a bad context', function(next) {
+            var config, context;
+            context = { device: 'torture' };
+            config = new Config();
+            config
+              .addConfigPromise(
+                'simple',
+                'dimensions',
+                libpath.resolve(touchdown, 'configs/dimensions.json')
+              )
+              .then(() =>
+                config.addConfigPromise(
+                  'simple',
+                  'foo',
+                  libpath.resolve(touchdown, 'configs/foo.js')
+                )
+              )
+              .then(() => config.readNoMergePromise('simple', 'foo', context))
+              .then(have => {
+                expect(have.selector).to.be.an('undefined');
+                next();
+              });
+          });
+
+          it('freezes the config object if the `safeMode` option is passed', function(next) {
+            var config = new Config({
+              safeMode: true
+            });
+            config
+              .addConfigPromise(
+                'simple',
+                'dimensions',
+                libpath.resolve(touchdown, 'configs/dimensions.json')
+              )
+              .then(() =>
+                config.addConfigPromise(
+                  'simple',
+                  'foo',
+                  libpath.resolve(touchdown, 'configs/foo.js')
+                )
+              )
+              .then(() =>
+                config.readNoMergePromise('simple', 'foo', { device: 'mobile' })
+              )
+              .then(have => {
+                expect(have).to.be.an('array');
+                expect(have[0]).to.be.an('object');
+                expect(have[0].TODO).to.equal('TODO');
+                try {
+                  have[0].TODO = 'DONE';
+                } catch (err) {
                   expect(err.message).to.equal(
-                    'Unknown config "foo" in bundle "modown-newsboxes"'
+                    "Cannot assign to read only property 'TODO' of object '#<Object>'"
                   );
                   next();
-                })
-              );
-          });
-
-          it("reads non-contextualized .json config files", function(next) {
-            var config = new Config();
-            config
-              .addConfigPromise(
-                "simple",
-                "routes",
-                libpath.resolve(touchdown, "configs/dimensions.json")
-              )
-              .then(() =>
-                config.readPromise("simple", "routes", {}).then(have => {
-                  expect(have).to.be.an("array");
-                  expect(have[0]).to.be.an("object");
-                  expect(have[0].dimensions).to.be.an("array");
-                  next();
-                })
-              );
-          });
-
-          it("reads contextualized .js config files", function(next) {
-            var config = new Config();
-            config
-              .addConfigPromise(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "simple",
-                    "foo",
-                    libpath.resolve(touchdown, "configs/foo.js")
-                  )
-                  .then(() =>
-                    config
-                      .readPromise("simple", "foo", { device: "mobile" })
-                      .then(have => {
-                        expect(have).to.be.an("object");
-                        expect(have.TODO).to.equal("TODO");
-                        expect(have.selector).to.equal("mobile");
-                        next();
-                      })
-                  )
-              );
-          });
-
-          it("reads contextualized .json config files", function(next) {
-            var config = new Config();
-            config
-              .addConfigPromise(
-                "modown",
-                "dimensions",
-                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "modown-newsboxes",
-                    "application",
-                    libpath.resolve(mojito, "application.json")
-                  )
-                  .then(() =>
-                    config
-                      .readPromise("modown-newsboxes", "application", {
-                        device: "mobile"
-                      })
-                      .then(have => {
-                        expect(have).to.be.an("object");
-                        expect(have.TODO).to.equal("TODO");
-                        expect(have.selector).to.equal("mobile");
-                        next();
-                      })
-                  )
-              );
-          });
-
-          it("applies baseContext", function(next) {
-            var config = new Config({
-              baseContext: {
-                device: "mobile"
-              }
-            });
-            config
-              .addConfigPromise(
-                "modown",
-                "dimensions",
-                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "modown-newsboxes",
-                    "application",
-                    libpath.resolve(mojito, "application.json")
-                  )
-                  .then(() =>
-                    config
-                      .readPromise("modown-newsboxes", "application", {})
-                      .then(have => {
-                        expect(have).to.be.an("object");
-                        expect(have.TODO).to.equal("TODO");
-                        expect(have.selector).to.equal("mobile");
-                        next();
-                      })
-                  )
-              );
-          });
-
-          it("survives a bad context", function(next) {
-            var config, context;
-            context = { device: "torture" };
-            config = new Config();
-            config
-              .addConfigPromise(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "simple",
-                    "foo",
-                    libpath.resolve(touchdown, "configs/foo.js")
-                  )
-                  .then(() =>
-                    config.readPromise("simple", "foo", context).then(have => {
-                      expect(have.selector).to.be.an("undefined");
-                      next();
-                    })
-                  )
-              );
-          });
-
-          it("freezes the config object if the `safeMode` option is passed", function(next) {
-            var config = new Config({
-              safeMode: true
-            });
-            config
-              .addConfigPromise(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "simple",
-                    "foo",
-                    libpath.resolve(touchdown, "configs/foo.js")
-                  )
-                  .then(() =>
-                    config
-                      .readPromise("simple", "foo", { device: "mobile" })
-                      .then(have => {
-                        expect(have).to.be.an("object");
-                        expect(have.TODO).to.equal("TODO");
-                        next();
-                      })
-                  )
-              );
+                }
+              });
           });
         });
 
-        describe("readNoMerge()", function() {
-          it("fails on unknown bundle", function(next) {
-            var config = new Config();
-            config.readNoMergePromise("foo", "bar", {}).catch(err => {
-              expect(err.message).to.equal('Unknown bundle "foo"');
-              next();
-            });
-          });
-
-          it("fails on unknown config", function(next) {
+        describe('readDimensionsPromise()', function() {
+          it('mojito-newsboxes', function(next) {
             var config = new Config();
             config
               .addConfigPromise(
-                "modown-newsboxes",
-                "application",
-                libpath.resolve(mojito, "application.json")
+                'modown',
+                'dimensions',
+                libpath.resolve(mojito, 'node_modules/modown/dimensions.json')
               )
-              .then(() =>
-                config
-                  .readNoMergePromise("modown-newsboxes", "foo", {})
-                  .catch(err => {
-                    expect(err.message).to.equal(
-                      'Unknown config "foo" in bundle "modown-newsboxes"'
-                    );
-                    next();
-                  })
-              );
+              .then(() => config.readDimensionsPromise())
+              .then(dims => {
+                expect(dims).to.be.an('array');
+                expect(dims[0]).to.have.property('runtime');
+                next();
+              });
           });
 
-          it("reads non-contextualized .json config files", function(next) {
+          it('touchdown-simple', function(next) {
             var config = new Config();
             config
               .addConfigPromise(
-                "simple",
-                "routes",
-                libpath.resolve(touchdown, "configs/dimensions.json")
+                'simple',
+                'dimensions',
+                libpath.resolve(touchdown, 'configs/dimensions.json')
               )
-              .then(() =>
-                config.readNoMergePromise("simple", "routes", {}).then(have => {
-                  expect(have).to.be.an("array");
-                  expect(have[0]).to.be.an("array");
-                  expect(have[0][0]).to.be.an("object");
-                  expect(have[0][0].dimensions).to.be.an("array");
-                  next();
-                })
-              );
-          });
-
-          it("reads contextualized .js config files", function(next) {
-            var config = new Config();
-            config
-              .addConfigPromise(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "simple",
-                    "foo",
-                    libpath.resolve(touchdown, "configs/foo.js")
-                  )
-                  .then(() =>
-                    config
-                      .readNoMergePromise("simple", "foo", { device: "mobile" })
-                      .then(have => {
-                        expect(have).to.be.an("array");
-                        expect(have[0]).to.be.an("object");
-                        expect(have[0].TODO).to.equal("TODO");
-                        expect(have[1]).to.be.an("object");
-                        expect(have[1].selector).to.equal("mobile");
-                        next();
-                      })
-                  )
-              );
-          });
-
-          it("reads contextualized .json config files", function(next) {
-            var config = new Config();
-            config
-              .addConfigPromise(
-                "modown",
-                "dimensions",
-                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "modown-newsboxes",
-                    "application",
-                    libpath.resolve(mojito, "application.json")
-                  )
-                  .then(() =>
-                    config
-                      .readNoMergePromise("modown-newsboxes", "application", {
-                        device: "mobile"
-                      })
-                      .then(have => {
-                        expect(have).to.be.an("array");
-                        expect(have[0]).to.be.an("object");
-                        expect(have[0].TODO).to.equal("TODO");
-                        expect(have[1]).to.be.an("object");
-                        expect(have[1].selector).to.equal("mobile");
-                        next();
-                      })
-                  )
-              );
-          });
-
-          it("applies baseContext", function(next) {
-            var config = new Config({
-              baseContext: {
-                device: "mobile"
-              }
-            });
-            config
-              .addConfigPromise(
-                "modown",
-                "dimensions",
-                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "modown-newsboxes",
-                    "application",
-                    libpath.resolve(mojito, "application.json")
-                  )
-                  .then(() =>
-                    config
-                      .readNoMergePromise("modown-newsboxes", "application", {})
-                      .then(have => {
-                        expect(have).to.be.an("array");
-                        expect(have[0]).to.be.an("object");
-                        expect(have[0].TODO).to.equal("TODO");
-                        expect(have[1]).to.be.an("object");
-                        expect(have[1].selector).to.equal("mobile");
-                        next();
-                      })
-                  )
-              );
-          });
-
-          it("survives a bad context", function(next) {
-            var config, context;
-            context = { device: "torture" };
-            config = new Config();
-            config
-              .addConfigPromise(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "simple",
-                    "foo",
-                    libpath.resolve(touchdown, "configs/foo.js")
-                  )
-                  .then(() =>
-                    config
-                      .readNoMergePromise("simple", "foo", context)
-                      .then(have => {
-                        expect(have.selector).to.be.an("undefined");
-                        next();
-                      })
-                  )
-              );
-          });
-
-          it("freezes the config object if the `safeMode` option is passed", function(next) {
-            var config = new Config({
-              safeMode: true
-            });
-            config
-              .addConfigPromise(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "simple",
-                    "foo",
-                    libpath.resolve(touchdown, "configs/foo.js")
-                  )
-                  .then(() =>
-                    config
-                      .readNoMergePromise("simple", "foo", { device: "mobile" })
-                      .then(have => {
-                        expect(have).to.be.an("array");
-                        expect(have[0]).to.be.an("object");
-                        expect(have[0].TODO).to.equal("TODO");
-                        try {
-                          have[0].TODO = "DONE";
-                        } catch (err) {
-                          expect(err.message).to.equal(
-                            "Cannot assign to read only property 'TODO' of object '#<Object>'"
-                          );
-                          next();
-                        }
-                      })
-                  )
-              );
-          });
-        });
-
-        describe("readDimensionsPromise()", function() {
-          it("mojito-newsboxes", function(next) {
-            var config = new Config();
-            config
-              .addConfigPromise(
-                "modown",
-                "dimensions",
-                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
-              )
-              .then(() =>
-                config.readDimensionsPromise().then(dims => {
-                  expect(dims).to.be.an("array");
-                  expect(dims[0]).to.have.property("runtime");
-                  next();
-                })
-              );
-          });
-
-          it("touchdown-simple", function(next) {
-            var config = new Config();
-            config
-              .addConfigPromise(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json")
-              )
-              .then(() =>
-                config.readDimensionsPromise().then(dims => {
-                  expect(dims).to.be.an("array");
-                  expect(dims[0]).to.have.property("ynet");
-                  next();
-                })
-              );
+              .then(() => config.readDimensionsPromise())
+              .then(dims => {
+                expect(dims).to.be.an('array');
+                expect(dims[0]).to.have.property('ynet');
+                next();
+              });
           });
         });
         /* jshint ignore:end */

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -1077,56 +1077,56 @@ describe('config', function () {
 
           it("fails on unknown config", function(next) {
             var config = new Config();
-            config.addConfig(
-              "modown-newsboxes",
-              "application",
-              libpath.resolve(mojito, "application.json"),
-              function(err) {
+            config
+              .addConfigPromise(
+                "modown-newsboxes",
+                "application",
+                libpath.resolve(mojito, "application.json")
+              )
+              .then(() =>
                 config.readPromise("modown-newsboxes", "foo", {}).catch(err => {
                   expect(err.message).to.equal(
                     'Unknown config "foo" in bundle "modown-newsboxes"'
                   );
                   next();
-                });
-              }
-            );
+                })
+              );
           });
 
           it("reads non-contextualized .json config files", function(next) {
             var config = new Config();
-            config.addConfig(
-              "simple",
-              "routes",
-              libpath.resolve(touchdown, "configs/dimensions.json"),
-              function(err) {
+            config
+              .addConfigPromise(
+                "simple",
+                "routes",
+                libpath.resolve(touchdown, "configs/dimensions.json")
+              )
+              .then(() =>
                 config.readPromise("simple", "routes", {}).then(have => {
                   expect(have).to.be.an("array");
                   expect(have[0]).to.be.an("object");
                   expect(have[0].dimensions).to.be.an("array");
                   next();
-                });
-              }
-            );
+                })
+              );
           });
 
           it("reads contextualized .js config files", function(next) {
             var config = new Config();
-            config.addConfig(
-              "simple",
-              "dimensions",
-              libpath.resolve(touchdown, "configs/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
-                config.addConfig(
-                  "simple",
-                  "foo",
-                  libpath.resolve(touchdown, "configs/foo.js"),
-                  function(err) {
-                    if (err) {
-                      throw err;
-                    }
+            config
+              .addConfigPromise(
+                "simple",
+                "dimensions",
+                libpath.resolve(touchdown, "configs/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "simple",
+                    "foo",
+                    libpath.resolve(touchdown, "configs/foo.js")
+                  )
+                  .then(() =>
                     config
                       .readPromise("simple", "foo", { device: "mobile" })
                       .then(have => {
@@ -1134,31 +1134,27 @@ describe('config', function () {
                         expect(have.TODO).to.equal("TODO");
                         expect(have.selector).to.equal("mobile");
                         next();
-                      });
-                  }
-                );
-              }
-            );
+                      })
+                  )
+              );
           });
 
           it("reads contextualized .json config files", function(next) {
             var config = new Config();
-            config.addConfig(
-              "modown",
-              "dimensions",
-              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
-                config.addConfig(
-                  "modown-newsboxes",
-                  "application",
-                  libpath.resolve(mojito, "application.json"),
-                  function(err) {
-                    if (err) {
-                      throw err;
-                    }
+            config
+              .addConfigPromise(
+                "modown",
+                "dimensions",
+                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "modown-newsboxes",
+                    "application",
+                    libpath.resolve(mojito, "application.json")
+                  )
+                  .then(() =>
                     config
                       .readPromise("modown-newsboxes", "application", {
                         device: "mobile"
@@ -1168,11 +1164,9 @@ describe('config', function () {
                         expect(have.TODO).to.equal("TODO");
                         expect(have.selector).to.equal("mobile");
                         next();
-                      });
-                  }
-                );
-              }
-            );
+                      })
+                  )
+              );
           });
 
           it("applies baseContext", function(next) {
@@ -1181,19 +1175,20 @@ describe('config', function () {
                 device: "mobile"
               }
             });
-            config.addConfig(
-              "modown",
-              "dimensions",
-              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
-              function() {
-                config.addConfig(
-                  "modown-newsboxes",
-                  "application",
-                  libpath.resolve(mojito, "application.json"),
-                  function(err) {
-                    if (err) {
-                      throw err;
-                    }
+            config
+              .addConfigPromise(
+                "modown",
+                "dimensions",
+                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "modown-newsboxes",
+                    "application",
+                    libpath.resolve(mojito, "application.json")
+                  )
+                  .then(() =>
                     config
                       .readPromise("modown-newsboxes", "application", {})
                       .then(have => {
@@ -1201,77 +1196,66 @@ describe('config', function () {
                         expect(have.TODO).to.equal("TODO");
                         expect(have.selector).to.equal("mobile");
                         next();
-                      });
-                  }
-                );
-              }
-            );
+                      })
+                  )
+              );
           });
 
           it("survives a bad context", function(next) {
             var config, context;
             context = { device: "torture" };
             config = new Config();
-            config.addConfig(
-              "simple",
-              "dimensions",
-              libpath.resolve(touchdown, "configs/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
-                config.addConfig(
-                  "simple",
-                  "foo",
-                  libpath.resolve(touchdown, "configs/foo.js"),
-                  function(err) {
-                    if (err) {
-                      throw err;
-                    }
+            config
+              .addConfigPromise(
+                "simple",
+                "dimensions",
+                libpath.resolve(touchdown, "configs/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "simple",
+                    "foo",
+                    libpath.resolve(touchdown, "configs/foo.js")
+                  )
+                  .then(() =>
                     config.readPromise("simple", "foo", context).then(have => {
                       expect(have.selector).to.be.an("undefined");
                       next();
-                    });
-                  }
-                );
-              }
-            );
+                    })
+                  )
+              );
           });
 
           it("freezes the config object if the `safeMode` option is passed", function(next) {
             var config = new Config({
               safeMode: true
             });
-            config.addConfig(
-              "simple",
-              "dimensions",
-              libpath.resolve(touchdown, "configs/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
-                config.addConfig(
-                  "simple",
-                  "foo",
-                  libpath.resolve(touchdown, "configs/foo.js"),
-                  function(err) {
-                    if (err) {
-                      throw err;
-                    }
+            config
+              .addConfigPromise(
+                "simple",
+                "dimensions",
+                libpath.resolve(touchdown, "configs/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "simple",
+                    "foo",
+                    libpath.resolve(touchdown, "configs/foo.js")
+                  )
+                  .then(() =>
                     config
                       .readPromise("simple", "foo", { device: "mobile" })
                       .then(have => {
                         expect(have).to.be.an("object");
                         expect(have.TODO).to.equal("TODO");
                         next();
-                      });
-                  }
-                );
-              }
-            );
+                      })
+                  )
+              );
           });
         });
-
 
         describe("readNoMerge()", function() {
           it("fails on unknown bundle", function(next) {
@@ -1284,14 +1268,13 @@ describe('config', function () {
 
           it("fails on unknown config", function(next) {
             var config = new Config();
-            config.addConfig(
-              "modown-newsboxes",
-              "application",
-              libpath.resolve(mojito, "application.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
+            config
+              .addConfigPromise(
+                "modown-newsboxes",
+                "application",
+                libpath.resolve(mojito, "application.json")
+              )
+              .then(() =>
                 config
                   .readNoMergePromise("modown-newsboxes", "foo", {})
                   .catch(err => {
@@ -1299,47 +1282,45 @@ describe('config', function () {
                       'Unknown config "foo" in bundle "modown-newsboxes"'
                     );
                     next();
-                  });
-              }
-            );
+                  })
+              );
           });
 
           it("reads non-contextualized .json config files", function(next) {
             var config = new Config();
-            config.addConfig(
-              "simple",
-              "routes",
-              libpath.resolve(touchdown, "configs/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
+            config
+              .addConfigPromise(
+                "simple",
+                "routes",
+                libpath.resolve(touchdown, "configs/dimensions.json")
+              )
+              .then(() =>
                 config.readNoMergePromise("simple", "routes", {}).then(have => {
                   expect(have).to.be.an("array");
                   expect(have[0]).to.be.an("array");
                   expect(have[0][0]).to.be.an("object");
                   expect(have[0][0].dimensions).to.be.an("array");
                   next();
-                });
-              }
-            );
+                })
+              );
           });
 
           it("reads contextualized .js config files", function(next) {
             var config = new Config();
-            config.addConfig(
-              "simple",
-              "dimensions",
-              libpath.resolve(touchdown, "configs/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
-                config.addConfig(
-                  "simple",
-                  "foo",
-                  libpath.resolve(touchdown, "configs/foo.js"),
-                  function(err) {
+            config
+              .addConfigPromise(
+                "simple",
+                "dimensions",
+                libpath.resolve(touchdown, "configs/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "simple",
+                    "foo",
+                    libpath.resolve(touchdown, "configs/foo.js")
+                  )
+                  .then(() =>
                     config
                       .readNoMergePromise("simple", "foo", { device: "mobile" })
                       .then(have => {
@@ -1349,31 +1330,27 @@ describe('config', function () {
                         expect(have[1]).to.be.an("object");
                         expect(have[1].selector).to.equal("mobile");
                         next();
-                      });
-                  }
-                );
-              }
-            );
+                      })
+                  )
+              );
           });
 
           it("reads contextualized .json config files", function(next) {
             var config = new Config();
-            config.addConfig(
-              "modown",
-              "dimensions",
-              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
-                config.addConfig(
-                  "modown-newsboxes",
-                  "application",
-                  libpath.resolve(mojito, "application.json"),
-                  function(err) {
-                    if (err) {
-                      throw err;
-                    }
+            config
+              .addConfigPromise(
+                "modown",
+                "dimensions",
+                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "modown-newsboxes",
+                    "application",
+                    libpath.resolve(mojito, "application.json")
+                  )
+                  .then(() =>
                     config
                       .readNoMergePromise("modown-newsboxes", "application", {
                         device: "mobile"
@@ -1385,11 +1362,9 @@ describe('config', function () {
                         expect(have[1]).to.be.an("object");
                         expect(have[1].selector).to.equal("mobile");
                         next();
-                      });
-                  }
-                );
-              }
-            );
+                      })
+                  )
+              );
           });
 
           it("applies baseContext", function(next) {
@@ -1398,22 +1373,20 @@ describe('config', function () {
                 device: "mobile"
               }
             });
-            config.addConfig(
-              "modown",
-              "dimensions",
-              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
-                config.addConfig(
-                  "modown-newsboxes",
-                  "application",
-                  libpath.resolve(mojito, "application.json"),
-                  function(err) {
-                    if (err) {
-                      throw err;
-                    }
+            config
+              .addConfigPromise(
+                "modown",
+                "dimensions",
+                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "modown-newsboxes",
+                    "application",
+                    libpath.resolve(mojito, "application.json")
+                  )
+                  .then(() =>
                     config
                       .readNoMergePromise("modown-newsboxes", "application", {})
                       .then(have => {
@@ -1423,65 +1396,57 @@ describe('config', function () {
                         expect(have[1]).to.be.an("object");
                         expect(have[1].selector).to.equal("mobile");
                         next();
-                      });
-                  }
-                );
-              }
-            );
+                      })
+                  )
+              );
           });
 
           it("survives a bad context", function(next) {
             var config, context;
             context = { device: "torture" };
             config = new Config();
-            config.addConfig(
-              "simple",
-              "dimensions",
-              libpath.resolve(touchdown, "configs/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
-                config.addConfig(
-                  "simple",
-                  "foo",
-                  libpath.resolve(touchdown, "configs/foo.js"),
-                  function(err) {
-                    if (err) {
-                      throw err;
-                    }
+            config
+              .addConfigPromise(
+                "simple",
+                "dimensions",
+                libpath.resolve(touchdown, "configs/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "simple",
+                    "foo",
+                    libpath.resolve(touchdown, "configs/foo.js")
+                  )
+                  .then(() =>
                     config
                       .readNoMergePromise("simple", "foo", context)
                       .then(have => {
                         expect(have.selector).to.be.an("undefined");
                         next();
-                      });
-                  }
-                );
-              }
-            );
+                      })
+                  )
+              );
           });
 
           it("freezes the config object if the `safeMode` option is passed", function(next) {
             var config = new Config({
               safeMode: true
             });
-            config.addConfig(
-              "simple",
-              "dimensions",
-              libpath.resolve(touchdown, "configs/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
-                config.addConfig(
-                  "simple",
-                  "foo",
-                  libpath.resolve(touchdown, "configs/foo.js"),
-                  function(err) {
-                    if (err) {
-                      throw err;
-                    }
+            config
+              .addConfigPromise(
+                "simple",
+                "dimensions",
+                libpath.resolve(touchdown, "configs/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "simple",
+                    "foo",
+                    libpath.resolve(touchdown, "configs/foo.js")
+                  )
+                  .then(() =>
                     config
                       .readNoMergePromise("simple", "foo", { device: "mobile" })
                       .then(have => {
@@ -1496,46 +1461,45 @@ describe('config', function () {
                           );
                           next();
                         }
-                      });
-                  }
-                );
-              }
-            );
+                      })
+                  )
+              );
           });
         });
-
 
         describe("readDimensionsPromise()", function() {
           it("mojito-newsboxes", function(next) {
             var config = new Config();
-            config.addConfig(
-              "modown",
-              "dimensions",
-              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
-              function(err, data) {
+            config
+              .addConfigPromise(
+                "modown",
+                "dimensions",
+                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
+              )
+              .then(() =>
                 config.readDimensionsPromise().then(dims => {
                   expect(dims).to.be.an("array");
                   expect(dims[0]).to.have.property("runtime");
                   next();
-                });
-              }
-            );
+                })
+              );
           });
 
           it("touchdown-simple", function(next) {
             var config = new Config();
-            config.addConfig(
-              "simple",
-              "dimensions",
-              libpath.resolve(touchdown, "configs/dimensions.json"),
-              function(err, data) {
+            config
+              .addConfigPromise(
+                "simple",
+                "dimensions",
+                libpath.resolve(touchdown, "configs/dimensions.json")
+              )
+              .then(() =>
                 config.readDimensionsPromise().then(dims => {
                   expect(dims).to.be.an("array");
                   expect(dims[0]).to.have.property("ynet");
                   next();
-                });
-              }
-            );
+                })
+              );
           });
         });
         /* jshint ignore:end */


### PR DESCRIPTION
Refer to the issue https://github.com/yahoo/ycb-config/issues/21 I said, if we could return promise in our async function, it will reduce our function nested callback, I use the new method name `readPromise` which just a wrap of orignal method `read` and pass the callback to exchange fulfilled / rejected state as `promisify` do.

The testing code are just a POC for all `read()` functionality, we could make promised interface easily , actually we only need to test the correct `thisArgs` are passed to the original method in the future.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
