### PR TITLE
Promise usage - Another type api (config.promises.read)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,6 @@ helper.readDimensions(function(err, dimensions) {
 YCB Config lets you read just the dimensions that are available for you to contextualize a request that's
 coming in.  This can be an array of properties such as device type, language, feature bucket, or more.
 
-
 ### Promises
 
 The following methods do not require a `callback` parameter, they will return Promise so that you can use chainable methods (such as` then` and `catch`) or` async` and `await` to handle asynchronous operations.

--- a/README.md
+++ b/README.md
@@ -177,6 +177,94 @@ helper.readDimensions(function(err, dimensions) {
 YCB Config lets you read just the dimensions that are available for you to contextualize a request that's
 coming in.  This can be an array of properties such as device type, language, feature bucket, or more.
 
+### Promises
+
+The following methods do not require a `callback` parameter, they will return Promise so that you can use chainable methods (such as` then` and `catch`) or` async` and `await` to handle asynchronous operations.
+
+#### `helper.promises.addConfig(bundleName, configName, path)`
+
+Example:
+
+```js
+helper.promises.addConfig('homepage', 'weather-widget', 'config/application.json')
+    .then(function(config){
+        /**
+         * `config` contains the configuration you just added as a JavaScript object
+         * Properties within it will vary depending on your configuration file.
+         */
+    })
+```
+
+#### `helper.promises.read(bundleName, configName, context)`
+
+Example:
+
+```js
+// This contextual information is usually obtained from some custom middleware in your application.
+var context = {
+    'device': 'iphone',
+    'locale': 'en-US',
+    'bucket': 'new-feature-x'
+};
+
+// This requires that the config we're reading has already been added through `addConfig`.
+helper.promises.read('homepage', 'weather-widget', context)
+    .then(function(config){
+        /**
+         * The `config` object now contains the correct configuration settings for
+         * our context above.  You can use it to render a template correctly for an
+         * iPhone, with the right localization settings for the US, and with the new
+         * feature you're bucket testing for.
+         */
+    })
+```
+
+#### `helper.promises.readNoMerge(bundleName, configName, context)`
+
+Example:
+
+```js
+// This contextual information is usually obtained from some custom middleware in your application.
+var context = {
+    'device': 'iphone',
+    'locale': 'en-US',
+    'bucket': 'new-feature-x'
+};
+
+// This requires that the config we're reading has already been added through `addConfig`.
+helper.readNoMerge('homepage', 'weather-widget', context)
+    .then(function(configs){
+        /**
+         * The `configs` variable now contains an array of configuration settings, based on
+         * the individual selectors, from most specific to least specific.
+         *
+         * Like before, you can use them to render a template correctly for an
+         * iPhone, with the right localization settings for the US, and with the new
+         * feature you're bucket testing for.
+         *
+         * This time, though, it's up to you to merge the individual configs instead of having
+         * them automatically merged for you.
+         */
+    });
+```
+
+#### `helper.promises.readDimensions()`
+
+Example:
+
+```js
+// This requires that the config we're reading has already been added through `addConfig`
+helper.promises.readDimensions
+    .then(function(dimensions) {
+        /**
+         * The `dimensions` variable contains an array of objects containing all of the possible
+         * selectors that can be used to contextualize a request that's coming in.
+         * See https://github.com/yahoo/ycb/blob/master/examples/full/dimensions.json
+         * for an example of what this could look like.
+         */
+    });
+```
+
 ## License
 This software is free to use under the Yahoo Inc. BSD license.
 See the [LICENSE file][] for license text and copyright information.

--- a/README.md
+++ b/README.md
@@ -278,7 +278,6 @@ helper.read(bundle, config, context, callback);
 The time value in the context should be a millisecond timestamp. To use a custom time dimension
 it may specified asn an option:`new ConfigHelper({timeDimension: 'my-time-key'})`.
 
-
 ## License
 This software is free to use under the Yahoo Inc. BSD license.
 See the [LICENSE file][] for license text and copyright information.

--- a/lib/index.js
+++ b/lib/index.js
@@ -662,7 +662,7 @@ Config.prototype._mergeBaseContext = function (context) {
 
 Config.prototype.addConfigPromise = promisify(Config.prototype.addConfig);
 Config.prototype.addConfigContentsPromise = promisify(
-  Config.prototype.addConfigContentsPromise
+  Config.prototype.addConfigContents
 );
 Config.prototype.readPromise = promisify(Config.prototype.read);
 Config.prototype.readNoMergePromise = promisify(Config.prototype.readNoMerge);

--- a/lib/index.js
+++ b/lib/index.js
@@ -659,6 +659,17 @@ Config.prototype._mergeBaseContext = function (context) {
     return mix(clone(context), this._options.baseContext);
 };
 
+Config.prototype.readPromise = function(bundleName, configName, context) {
+  var self = this;
+  return new Promise(function(resolve, reject) {//jshint ignore:line
+     self.read(bundleName, configName, context, function(err, result) {
+      if (err) {
+        reject(err);
+      }
+      resolve(result);
+    });
+  });
+};
 
 module.exports = Config;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ var libfs       = require('fs'),
     libyaml     = require('yamljs'),
     libcache    = require('lru-cache'),
     deepFreeze  = require('deep-freeze'),
+    promisify   = require('util').promisify,
 
     MESSAGES = {
         'unknown bundle': 'Unknown bundle "%s"',
@@ -659,17 +660,15 @@ Config.prototype._mergeBaseContext = function (context) {
     return mix(clone(context), this._options.baseContext);
 };
 
-Config.prototype.readPromise = function(bundleName, configName, context) {
-  var self = this;
-  return new Promise(function(resolve, reject) {//jshint ignore:line
-     self.read(bundleName, configName, context, function(err, result) {
-      if (err) {
-        reject(err);
-      }
-      resolve(result);
-    });
-  });
-};
+Config.prototype.addConfigPromise = promisify(Config.prototype.addConfig);
+Config.prototype.addConfigContentsPromise = promisify(
+  Config.prototype.addConfigContentsPromise
+);
+Config.prototype.readPromise = promisify(Config.prototype.read);
+Config.prototype.readNoMergePromise = promisify(Config.prototype.readNoMerge);
+Config.prototype.readDimensionsPromise = promisify(
+  Config.prototype.readDimensions
+);
 
 module.exports = Config;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -193,6 +193,13 @@ function Config(options) {
     // cached data:
     this._configYCBs = {};  // fullpath: YCB object
     this._configCache = {}; // bundle: config: context: config
+    this.promises = {
+      addConfig: promisify(Config.prototype.addConfig).bind(this),
+      addConfigContents: promisify(Config.prototype.addConfigContents).bind(this),
+      read: promisify(Config.prototype.read).bind(this),
+      readNoMerge: promisify(Config.prototype.readNoMerge).bind(this),
+      readDimensions: promisify(Config.prototype.readDimensions).bind(this)
+    };
 }
 Config.prototype = {};
 
@@ -660,15 +667,6 @@ Config.prototype._mergeBaseContext = function (context) {
     return mix(clone(context), this._options.baseContext);
 };
 
-Config.prototype.addConfigPromise = promisify(Config.prototype.addConfig);
-Config.prototype.addConfigContentsPromise = promisify(
-  Config.prototype.addConfigContents
-);
-Config.prototype.readPromise = promisify(Config.prototype.read);
-Config.prototype.readNoMergePromise = promisify(Config.prototype.readNoMerge);
-Config.prototype.readDimensionsPromise = promisify(
-  Config.prototype.readDimensions
-);
 
 module.exports = Config;
 

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -1066,10 +1066,10 @@ describe('config', function () {
 
 
         /* jshint ignore:start */
-        describe('readPromises()', function() {
+        describe('promises.read()', function() {
           it('fails on unknown bundle', function(next) {
             var config = new Config();
-            config.readPromise('foo', 'bar', {}).catch(err => {
+            config.promises.read('foo', 'bar', {}).catch(err => {
               expect(err.message).to.equal('Unknown bundle "foo"');
               next();
             });
@@ -1078,12 +1078,13 @@ describe('config', function () {
           it('fails on unknown config', function(next) {
             var config = new Config();
             config
-              .addConfigPromise(
+            .promises
+            .addConfig(
                 'modown-newsboxes',
                 'application',
                 libpath.resolve(mojito, 'application.json')
               )
-              .then(() => config.readPromise('modown-newsboxes', 'foo', {}))
+              .then(() => config.promises.read('modown-newsboxes', 'foo', {}))
               .catch(err => {
                 expect(err.message).to.equal(
                   'Unknown config "foo" in bundle "modown-newsboxes"'
@@ -1095,12 +1096,13 @@ describe('config', function () {
           it('reads non-contextualized .json config files', function(next) {
             var config = new Config();
             config
-              .addConfigPromise(
+            .promises
+              .addConfig(
                 'simple',
                 'routes',
                 libpath.resolve(touchdown, 'configs/dimensions.json')
               )
-              .then(() => config.readPromise('simple', 'routes', {}))
+              .then(() => config.promises.read('simple', 'routes', {}))
               .then(have => {
                 expect(have).to.be.an('array');
                 expect(have[0]).to.be.an('object');
@@ -1112,20 +1114,20 @@ describe('config', function () {
           it('reads contextualized .js config files', function(next) {
             var config = new Config();
             config
-              .addConfigPromise(
+              .promises.addConfig(
                 'simple',
                 'dimensions',
                 libpath.resolve(touchdown, 'configs/dimensions.json')
               )
               .then(() =>
-                config.addConfigPromise(
+                config.promises.addConfig(
                   'simple',
                   'foo',
                   libpath.resolve(touchdown, 'configs/foo.js')
                 )
               )
               .then(() =>
-                config.readPromise('simple', 'foo', { device: 'mobile' })
+                config.promises.read('simple', 'foo', { device: 'mobile' })
               )
               .then(have => {
                 expect(have).to.be.an('object');
@@ -1138,20 +1140,20 @@ describe('config', function () {
           it('reads contextualized .json config files', function(next) {
             var config = new Config();
             config
-              .addConfigPromise(
+              .promises.addConfig(
                 'modown',
                 'dimensions',
                 libpath.resolve(mojito, 'node_modules/modown/dimensions.json')
               )
               .then(() =>
-                config.addConfigPromise(
+                config.promises.addConfig(
                   'modown-newsboxes',
                   'application',
                   libpath.resolve(mojito, 'application.json')
                 )
               )
               .then(() =>
-                config.readPromise('modown-newsboxes', 'application', {
+                config.promises.read('modown-newsboxes', 'application', {
                   device: 'mobile'
                 })
               )
@@ -1170,20 +1172,20 @@ describe('config', function () {
               }
             });
             config
-              .addConfigPromise(
+              .promises.addConfig(
                 'modown',
                 'dimensions',
                 libpath.resolve(mojito, 'node_modules/modown/dimensions.json')
               )
               .then(() =>
-                config.addConfigPromise(
+                config.promises.addConfig(
                   'modown-newsboxes',
                   'application',
                   libpath.resolve(mojito, 'application.json')
                 )
               )
               .then(() =>
-                config.readPromise('modown-newsboxes', 'application', {})
+                config.promises.read('modown-newsboxes', 'application', {})
               )
               .then(have => {
                 expect(have).to.be.an('object');
@@ -1198,20 +1200,20 @@ describe('config', function () {
             context = { device: 'torture' };
             config = new Config();
             config
-              .addConfigPromise(
+              .promises.addConfig(
                 'simple',
                 'dimensions',
                 libpath.resolve(touchdown, 'configs/dimensions.json')
               )
               .then(() =>
-                config.addConfigPromise(
+                config.promises.addConfig(
                   'simple',
                   'foo',
                   libpath.resolve(touchdown, 'configs/foo.js')
                 )
               )
               .then(() =>
-                config.readPromise('simple', 'foo', context).then(have => {
+                config.promises.read('simple', 'foo', context).then(have => {
                   expect(have.selector).to.be.an('undefined');
                   next();
                 })
@@ -1223,20 +1225,20 @@ describe('config', function () {
               safeMode: true
             });
             config
-              .addConfigPromise(
+              .promises.addConfig(
                 'simple',
                 'dimensions',
                 libpath.resolve(touchdown, 'configs/dimensions.json')
               )
               .then(() =>
-                config.addConfigPromise(
+                config.promises.addConfig(
                   'simple',
                   'foo',
                   libpath.resolve(touchdown, 'configs/foo.js')
                 )
               )
               .then(() =>
-                config.readPromise('simple', 'foo', { device: 'mobile' })
+                config.promises.read('simple', 'foo', { device: 'mobile' })
               )
               .then(have => {
                 expect(have).to.be.an('object');
@@ -1246,10 +1248,10 @@ describe('config', function () {
           });
         });
 
-        describe('readNoMerge()', function() {
+        describe('promises.readNoMerge()', function() {
           it('fails on unknown bundle', function(next) {
             var config = new Config();
-            config.readNoMergePromise('foo', 'bar', {}).catch(err => {
+            config.promises.readNoMerge('foo', 'bar', {}).catch(err => {
               expect(err.message).to.equal('Unknown bundle "foo"');
               next();
             });
@@ -1258,13 +1260,13 @@ describe('config', function () {
           it('fails on unknown config', function(next) {
             var config = new Config();
             config
-              .addConfigPromise(
+              .promises.addConfig(
                 'modown-newsboxes',
                 'application',
                 libpath.resolve(mojito, 'application.json')
               )
               .then(() =>
-                config.readNoMergePromise('modown-newsboxes', 'foo', {})
+                config.promises.readNoMerge('modown-newsboxes', 'foo', {})
               )
               .catch(err => {
                 expect(err.message).to.equal(
@@ -1277,12 +1279,12 @@ describe('config', function () {
           it('reads non-contextualized .json config files', function(next) {
             var config = new Config();
             config
-              .addConfigPromise(
+              .promises.addConfig(
                 'simple',
                 'routes',
                 libpath.resolve(touchdown, 'configs/dimensions.json')
               )
-              .then(() => config.readNoMergePromise('simple', 'routes', {}))
+              .then(() => config.promises.readNoMerge('simple', 'routes', {}))
               .then(have => {
                 expect(have).to.be.an('array');
                 expect(have[0]).to.be.an('array');
@@ -1295,20 +1297,20 @@ describe('config', function () {
           it('reads contextualized .js config files', function(next) {
             var config = new Config();
             config
-              .addConfigPromise(
+              .promises.addConfig(
                 'simple',
                 'dimensions',
                 libpath.resolve(touchdown, 'configs/dimensions.json')
               )
               .then(() =>
-                config.addConfigPromise(
+                config.promises.addConfig(
                   'simple',
                   'foo',
                   libpath.resolve(touchdown, 'configs/foo.js')
                 )
               )
               .then(() =>
-                config.readNoMergePromise('simple', 'foo', { device: 'mobile' })
+                config.promises.readNoMerge('simple', 'foo', { device: 'mobile' })
               )
               .then(have => {
                 expect(have).to.be.an('array');
@@ -1323,20 +1325,20 @@ describe('config', function () {
           it('reads contextualized .json config files', function(next) {
             var config = new Config();
             config
-              .addConfigPromise(
+              .promises.addConfig(
                 'modown',
                 'dimensions',
                 libpath.resolve(mojito, 'node_modules/modown/dimensions.json')
               )
               .then(() =>
-                config.addConfigPromise(
+                config.promises.addConfig(
                   'modown-newsboxes',
                   'application',
                   libpath.resolve(mojito, 'application.json')
                 )
               )
               .then(() =>
-                config.readNoMergePromise('modown-newsboxes', 'application', {
+                config.promises.readNoMerge('modown-newsboxes', 'application', {
                   device: 'mobile'
                 })
               )
@@ -1357,20 +1359,20 @@ describe('config', function () {
               }
             });
             config
-              .addConfigPromise(
+              .promises.addConfig(
                 'modown',
                 'dimensions',
                 libpath.resolve(mojito, 'node_modules/modown/dimensions.json')
               )
               .then(() =>
-                config.addConfigPromise(
+                config.promises.addConfig(
                   'modown-newsboxes',
                   'application',
                   libpath.resolve(mojito, 'application.json')
                 )
               )
               .then(() =>
-                config.readNoMergePromise('modown-newsboxes', 'application', {})
+                config.promises.readNoMerge('modown-newsboxes', 'application', {})
               )
               .then(have => {
                 expect(have).to.be.an('array');
@@ -1387,19 +1389,19 @@ describe('config', function () {
             context = { device: 'torture' };
             config = new Config();
             config
-              .addConfigPromise(
+              .promises.addConfig(
                 'simple',
                 'dimensions',
                 libpath.resolve(touchdown, 'configs/dimensions.json')
               )
               .then(() =>
-                config.addConfigPromise(
+                config.promises.addConfig(
                   'simple',
                   'foo',
                   libpath.resolve(touchdown, 'configs/foo.js')
                 )
               )
-              .then(() => config.readNoMergePromise('simple', 'foo', context))
+              .then(() => config.promises.readNoMerge('simple', 'foo', context))
               .then(have => {
                 expect(have.selector).to.be.an('undefined');
                 next();
@@ -1411,20 +1413,20 @@ describe('config', function () {
               safeMode: true
             });
             config
-              .addConfigPromise(
+              .promises.addConfig(
                 'simple',
                 'dimensions',
                 libpath.resolve(touchdown, 'configs/dimensions.json')
               )
               .then(() =>
-                config.addConfigPromise(
+                config.promises.addConfig(
                   'simple',
                   'foo',
                   libpath.resolve(touchdown, 'configs/foo.js')
                 )
               )
               .then(() =>
-                config.readNoMergePromise('simple', 'foo', { device: 'mobile' })
+                config.promises.readNoMerge('simple', 'foo', { device: 'mobile' })
               )
               .then(have => {
                 expect(have).to.be.an('array');
@@ -1442,16 +1444,16 @@ describe('config', function () {
           });
         });
 
-        describe('readDimensionsPromise()', function() {
+        describe('promises.readDimensions()', function() {
           it('mojito-newsboxes', function(next) {
             var config = new Config();
             config
-              .addConfigPromise(
+              .promises.addConfig(
                 'modown',
                 'dimensions',
                 libpath.resolve(mojito, 'node_modules/modown/dimensions.json')
               )
-              .then(() => config.readDimensionsPromise())
+              .then(() => config.promises.readDimensions())
               .then(dims => {
                 expect(dims).to.be.an('array');
                 expect(dims[0]).to.have.property('runtime');
@@ -1462,12 +1464,12 @@ describe('config', function () {
           it('touchdown-simple', function(next) {
             var config = new Config();
             config
-              .addConfigPromise(
+              .promises.addConfig(
                 'simple',
                 'dimensions',
                 libpath.resolve(touchdown, 'configs/dimensions.json')
               )
-              .then(() => config.readDimensionsPromise())
+              .then(() => config.promises.readDimensions())
               .then(dims => {
                 expect(dims).to.be.an('array');
                 expect(dims[0]).to.have.property('ynet');

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -1063,218 +1063,481 @@ describe('config', function () {
                 );
             });
         });
+
+
         /* jshint ignore:start */
-        describe("readPromises usage", function() {
-            it("fails on unknown bundle", function(next) {
-              var config = new Config();
-              config.readPromise("foo", "bar", {}).catch(err => {
-                expect(err.message).to.equal('Unknown bundle "foo"');
-                next();
-              });
-            });
-
-            it("fails on unknown config", function(next) {
-              var config = new Config();
-              config.addConfig(
-                "modown-newsboxes",
-                "application",
-                libpath.resolve(mojito, "application.json"),
-                function(err) {
-                  config
-                    .readPromise("modown-newsboxes", "foo", {})
-                    .catch(err =>{
-                      expect(err.message).to.equal(
-                        'Unknown config "foo" in bundle "modown-newsboxes"'
-                      )
-                    next();}
-                    )
-                }
-              );
-            });
-
-            it("reads non-contextualized .json config files", function(next) {
-              var config = new Config();
-              config.addConfig(
-                "simple",
-                "routes",
-                libpath.resolve(touchdown, "configs/dimensions.json"),
-                function(err) {
-                  config
-                    .readPromise("simple", "routes", {})
-                    .then(have => {
-                      expect(have).to.be.an("array");
-                      expect(have[0]).to.be.an("object");
-                      expect(have[0].dimensions).to.be.an("array");
-                      next();
-                    })
-                }
-              );
-            });
-
-            it("reads contextualized .js config files", function(next) {
-              var config = new Config();
-              config.addConfig(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json"),
-                function(err) {
-                  if (err) {
-                    throw err;
-                  }
-                  config.addConfig(
-                    "simple",
-                    "foo",
-                    libpath.resolve(touchdown, "configs/foo.js"),
-                    function(err) {
-                      if (err) {
-                        throw err;
-                      }
-                      config
-                        .readPromise("simple", "foo", { device: "mobile" })
-                        .then(have => {
-                          expect(have).to.be.an("object");
-                          expect(have.TODO).to.equal("TODO");
-                          expect(have.selector).to.equal("mobile");
-                          next()
-                        })
-                    }
-                  );
-                }
-              );
-            });
-
-            it("reads contextualized .json config files", function(next) {
-              var config = new Config();
-              config.addConfig(
-                "modown",
-                "dimensions",
-                libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
-                function(err) {
-                  if (err) {
-                    throw err;
-                  }
-                  config.addConfig(
-                    "modown-newsboxes",
-                    "application",
-                    libpath.resolve(mojito, "application.json"),
-                    function(err) {
-                      if (err) {
-                        throw err;
-                      }
-                      config
-                        .readPromise("modown-newsboxes", "application", {
-                          device: "mobile"
-                        })
-                        .then(have => {
-                          expect(have).to.be.an("object");
-                          expect(have.TODO).to.equal("TODO");
-                          expect(have.selector).to.equal("mobile");
-                          next();
-                        })
-                    }
-                  );
-                }
-              );
-            });
-
-            it("applies baseContext", function(next) {
-              var config = new Config({
-                baseContext: {
-                  device: "mobile"
-                }
-              });
-              config.addConfig(
-                "modown",
-                "dimensions",
-                libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
-                function() {
-                  config.addConfig(
-                    "modown-newsboxes",
-                    "application",
-                    libpath.resolve(mojito, "application.json"),
-                    function(err) {
-                      if (err) {
-                        throw err;
-                      }
-                      config
-                        .readPromise("modown-newsboxes", "application", {})
-                        .then(have => {
-                          expect(have).to.be.an("object");
-                          expect(have.TODO).to.equal("TODO");
-                          expect(have.selector).to.equal("mobile");
-                          next();
-                        })
-                    }
-                  );
-                }
-              );
-            });
-
-            it("survives a bad context", function(next) {
-              var config, context;
-              context = { device: "torture" };
-              config = new Config();
-              config.addConfig(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json"),
-                function(err) {
-                  if (err) {
-                    throw err;
-                  }
-                  config.addConfig(
-                    "simple",
-                    "foo",
-                    libpath.resolve(touchdown, "configs/foo.js"),
-                    function(err) {
-                      if (err) {
-                        throw err;
-                      }
-                      config
-                        .readPromise("simple", "foo", context)
-                        .then(have =>{
-                          expect(have.selector).to.be.an("undefined")
-                        next()}
-                        )
-                    }
-                  );
-                }
-              );
-            });
-
-            it("freezes the config object if the `safeMode` option is passed", function(next) {
-              var config = new Config({
-                safeMode: true
-              });
-              config.addConfig(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json"),
-                function(err) {
-                  if (err) {
-                    throw err;
-                  }
-                  config.addConfig(
-                    "simple",
-                    "foo",
-                    libpath.resolve(touchdown, "configs/foo.js"),
-                    function(err) {
-                      if (err) {
-                        throw err;
-                      }
-                      config
-                        .readPromise("simple", "foo", { device: "mobile" })
-                        .then(have => {
-                          expect(have).to.be.an("object");
-                          expect(have.TODO).to.equal("TODO");
-                          next()
-                        })
-                    }
-                  );
-                }
-              );
+        describe("readPromises()", function() {
+          it("fails on unknown bundle", function(next) {
+            var config = new Config();
+            config.readPromise("foo", "bar", {}).catch(err => {
+              expect(err.message).to.equal('Unknown bundle "foo"');
+              next();
             });
           });
+
+          it("fails on unknown config", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "modown-newsboxes",
+              "application",
+              libpath.resolve(mojito, "application.json"),
+              function(err) {
+                config.readPromise("modown-newsboxes", "foo", {}).catch(err => {
+                  expect(err.message).to.equal(
+                    'Unknown config "foo" in bundle "modown-newsboxes"'
+                  );
+                  next();
+                });
+              }
+            );
+          });
+
+          it("reads non-contextualized .json config files", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "simple",
+              "routes",
+              libpath.resolve(touchdown, "configs/dimensions.json"),
+              function(err) {
+                config.readPromise("simple", "routes", {}).then(have => {
+                  expect(have).to.be.an("array");
+                  expect(have[0]).to.be.an("object");
+                  expect(have[0].dimensions).to.be.an("array");
+                  next();
+                });
+              }
+            );
+          });
+
+          it("reads contextualized .js config files", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "simple",
+              "dimensions",
+              libpath.resolve(touchdown, "configs/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.addConfig(
+                  "simple",
+                  "foo",
+                  libpath.resolve(touchdown, "configs/foo.js"),
+                  function(err) {
+                    if (err) {
+                      throw err;
+                    }
+                    config
+                      .readPromise("simple", "foo", { device: "mobile" })
+                      .then(have => {
+                        expect(have).to.be.an("object");
+                        expect(have.TODO).to.equal("TODO");
+                        expect(have.selector).to.equal("mobile");
+                        next();
+                      });
+                  }
+                );
+              }
+            );
+          });
+
+          it("reads contextualized .json config files", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "modown",
+              "dimensions",
+              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.addConfig(
+                  "modown-newsboxes",
+                  "application",
+                  libpath.resolve(mojito, "application.json"),
+                  function(err) {
+                    if (err) {
+                      throw err;
+                    }
+                    config
+                      .readPromise("modown-newsboxes", "application", {
+                        device: "mobile"
+                      })
+                      .then(have => {
+                        expect(have).to.be.an("object");
+                        expect(have.TODO).to.equal("TODO");
+                        expect(have.selector).to.equal("mobile");
+                        next();
+                      });
+                  }
+                );
+              }
+            );
+          });
+
+          it("applies baseContext", function(next) {
+            var config = new Config({
+              baseContext: {
+                device: "mobile"
+              }
+            });
+            config.addConfig(
+              "modown",
+              "dimensions",
+              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
+              function() {
+                config.addConfig(
+                  "modown-newsboxes",
+                  "application",
+                  libpath.resolve(mojito, "application.json"),
+                  function(err) {
+                    if (err) {
+                      throw err;
+                    }
+                    config
+                      .readPromise("modown-newsboxes", "application", {})
+                      .then(have => {
+                        expect(have).to.be.an("object");
+                        expect(have.TODO).to.equal("TODO");
+                        expect(have.selector).to.equal("mobile");
+                        next();
+                      });
+                  }
+                );
+              }
+            );
+          });
+
+          it("survives a bad context", function(next) {
+            var config, context;
+            context = { device: "torture" };
+            config = new Config();
+            config.addConfig(
+              "simple",
+              "dimensions",
+              libpath.resolve(touchdown, "configs/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.addConfig(
+                  "simple",
+                  "foo",
+                  libpath.resolve(touchdown, "configs/foo.js"),
+                  function(err) {
+                    if (err) {
+                      throw err;
+                    }
+                    config.readPromise("simple", "foo", context).then(have => {
+                      expect(have.selector).to.be.an("undefined");
+                      next();
+                    });
+                  }
+                );
+              }
+            );
+          });
+
+          it("freezes the config object if the `safeMode` option is passed", function(next) {
+            var config = new Config({
+              safeMode: true
+            });
+            config.addConfig(
+              "simple",
+              "dimensions",
+              libpath.resolve(touchdown, "configs/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.addConfig(
+                  "simple",
+                  "foo",
+                  libpath.resolve(touchdown, "configs/foo.js"),
+                  function(err) {
+                    if (err) {
+                      throw err;
+                    }
+                    config
+                      .readPromise("simple", "foo", { device: "mobile" })
+                      .then(have => {
+                        expect(have).to.be.an("object");
+                        expect(have.TODO).to.equal("TODO");
+                        next();
+                      });
+                  }
+                );
+              }
+            );
+          });
+        });
+
+
+        describe("readNoMerge()", function() {
+          it("fails on unknown bundle", function(next) {
+            var config = new Config();
+            config.readNoMergePromise("foo", "bar", {}).catch(err => {
+              expect(err.message).to.equal('Unknown bundle "foo"');
+              next();
+            });
+          });
+
+          it("fails on unknown config", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "modown-newsboxes",
+              "application",
+              libpath.resolve(mojito, "application.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config
+                  .readNoMergePromise("modown-newsboxes", "foo", {})
+                  .catch(err => {
+                    expect(err.message).to.equal(
+                      'Unknown config "foo" in bundle "modown-newsboxes"'
+                    );
+                    next();
+                  });
+              }
+            );
+          });
+
+          it("reads non-contextualized .json config files", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "simple",
+              "routes",
+              libpath.resolve(touchdown, "configs/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.readNoMergePromise("simple", "routes", {}).then(have => {
+                  expect(have).to.be.an("array");
+                  expect(have[0]).to.be.an("array");
+                  expect(have[0][0]).to.be.an("object");
+                  expect(have[0][0].dimensions).to.be.an("array");
+                  next();
+                });
+              }
+            );
+          });
+
+          it("reads contextualized .js config files", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "simple",
+              "dimensions",
+              libpath.resolve(touchdown, "configs/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.addConfig(
+                  "simple",
+                  "foo",
+                  libpath.resolve(touchdown, "configs/foo.js"),
+                  function(err) {
+                    config
+                      .readNoMergePromise("simple", "foo", { device: "mobile" })
+                      .then(have => {
+                        expect(have).to.be.an("array");
+                        expect(have[0]).to.be.an("object");
+                        expect(have[0].TODO).to.equal("TODO");
+                        expect(have[1]).to.be.an("object");
+                        expect(have[1].selector).to.equal("mobile");
+                        next();
+                      });
+                  }
+                );
+              }
+            );
+          });
+
+          it("reads contextualized .json config files", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "modown",
+              "dimensions",
+              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.addConfig(
+                  "modown-newsboxes",
+                  "application",
+                  libpath.resolve(mojito, "application.json"),
+                  function(err) {
+                    if (err) {
+                      throw err;
+                    }
+                    config
+                      .readNoMergePromise("modown-newsboxes", "application", {
+                        device: "mobile"
+                      })
+                      .then(have => {
+                        expect(have).to.be.an("array");
+                        expect(have[0]).to.be.an("object");
+                        expect(have[0].TODO).to.equal("TODO");
+                        expect(have[1]).to.be.an("object");
+                        expect(have[1].selector).to.equal("mobile");
+                        next();
+                      });
+                  }
+                );
+              }
+            );
+          });
+
+          it("applies baseContext", function(next) {
+            var config = new Config({
+              baseContext: {
+                device: "mobile"
+              }
+            });
+            config.addConfig(
+              "modown",
+              "dimensions",
+              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.addConfig(
+                  "modown-newsboxes",
+                  "application",
+                  libpath.resolve(mojito, "application.json"),
+                  function(err) {
+                    if (err) {
+                      throw err;
+                    }
+                    config
+                      .readNoMergePromise("modown-newsboxes", "application", {})
+                      .then(have => {
+                        expect(have).to.be.an("array");
+                        expect(have[0]).to.be.an("object");
+                        expect(have[0].TODO).to.equal("TODO");
+                        expect(have[1]).to.be.an("object");
+                        expect(have[1].selector).to.equal("mobile");
+                        next();
+                      });
+                  }
+                );
+              }
+            );
+          });
+
+          it("survives a bad context", function(next) {
+            var config, context;
+            context = { device: "torture" };
+            config = new Config();
+            config.addConfig(
+              "simple",
+              "dimensions",
+              libpath.resolve(touchdown, "configs/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.addConfig(
+                  "simple",
+                  "foo",
+                  libpath.resolve(touchdown, "configs/foo.js"),
+                  function(err) {
+                    if (err) {
+                      throw err;
+                    }
+                    config
+                      .readNoMergePromise("simple", "foo", context)
+                      .then(have => {
+                        expect(have.selector).to.be.an("undefined");
+                        next();
+                      });
+                  }
+                );
+              }
+            );
+          });
+
+          it("freezes the config object if the `safeMode` option is passed", function(next) {
+            var config = new Config({
+              safeMode: true
+            });
+            config.addConfig(
+              "simple",
+              "dimensions",
+              libpath.resolve(touchdown, "configs/dimensions.json"),
+              function(err) {
+                if (err) {
+                  throw err;
+                }
+                config.addConfig(
+                  "simple",
+                  "foo",
+                  libpath.resolve(touchdown, "configs/foo.js"),
+                  function(err) {
+                    if (err) {
+                      throw err;
+                    }
+                    config
+                      .readNoMergePromise("simple", "foo", { device: "mobile" })
+                      .then(have => {
+                        expect(have).to.be.an("array");
+                        expect(have[0]).to.be.an("object");
+                        expect(have[0].TODO).to.equal("TODO");
+                        try {
+                          have[0].TODO = "DONE";
+                        } catch (err) {
+                          expect(err.message).to.equal(
+                            "Cannot assign to read only property 'TODO' of object '#<Object>'"
+                          );
+                          next();
+                        }
+                      });
+                  }
+                );
+              }
+            );
+          });
+        });
+
+
+        describe("readDimensionsPromise()", function() {
+          it("mojito-newsboxes", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "modown",
+              "dimensions",
+              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
+              function(err, data) {
+                config.readDimensionsPromise().then(dims => {
+                  expect(dims).to.be.an("array");
+                  expect(dims[0]).to.have.property("runtime");
+                  next();
+                });
+              }
+            );
+          });
+
+          it("touchdown-simple", function(next) {
+            var config = new Config();
+            config.addConfig(
+              "simple",
+              "dimensions",
+              libpath.resolve(touchdown, "configs/dimensions.json"),
+              function(err, data) {
+                config.readDimensionsPromise().then(dims => {
+                  expect(dims).to.be.an("array");
+                  expect(dims[0]).to.have.property("ynet");
+                  next();
+                });
+              }
+            );
+          });
+        });
         /* jshint ignore:end */
     });
 });

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -1067,12 +1067,10 @@ describe('config', function () {
         describe("readPromises usage", function() {
             it("fails on unknown bundle", function(next) {
               var config = new Config();
-              config
-                .readPromise("foo", "bar", {})
-                .catch(err =>
-                  expect(err.message).to.equal('Unknown bundle "foo"')
-                )
-                .finally(next);
+              config.readPromise("foo", "bar", {}).catch(err => {
+                expect(err.message).to.equal('Unknown bundle "foo"');
+                next();
+              });
             });
 
             it("fails on unknown config", function(next) {
@@ -1084,12 +1082,12 @@ describe('config', function () {
                 function(err) {
                   config
                     .readPromise("modown-newsboxes", "foo", {})
-                    .catch(err =>
+                    .catch(err =>{
                       expect(err.message).to.equal(
                         'Unknown config "foo" in bundle "modown-newsboxes"'
                       )
+                    next();}
                     )
-                    .finally(next);
                 }
               );
             });
@@ -1107,8 +1105,8 @@ describe('config', function () {
                       expect(have).to.be.an("array");
                       expect(have[0]).to.be.an("object");
                       expect(have[0].dimensions).to.be.an("array");
+                      next();
                     })
-                    .finally(next);
                 }
               );
             });
@@ -1137,8 +1135,8 @@ describe('config', function () {
                           expect(have).to.be.an("object");
                           expect(have.TODO).to.equal("TODO");
                           expect(have.selector).to.equal("mobile");
+                          next()
                         })
-                        .finally(next);
                     }
                   );
                 }
@@ -1171,8 +1169,8 @@ describe('config', function () {
                           expect(have).to.be.an("object");
                           expect(have.TODO).to.equal("TODO");
                           expect(have.selector).to.equal("mobile");
+                          next();
                         })
-                        .finally(next);
                     }
                   );
                 }
@@ -1204,8 +1202,8 @@ describe('config', function () {
                           expect(have).to.be.an("object");
                           expect(have.TODO).to.equal("TODO");
                           expect(have.selector).to.equal("mobile");
+                          next();
                         })
-                        .then(next);
                     }
                   );
                 }
@@ -1234,10 +1232,10 @@ describe('config', function () {
                       }
                       config
                         .readPromise("simple", "foo", context)
-                        .then(have =>
+                        .then(have =>{
                           expect(have.selector).to.be.an("undefined")
+                        next()}
                         )
-                        .finally(next);
                     }
                   );
                 }
@@ -1269,8 +1267,8 @@ describe('config', function () {
                         .then(have => {
                           expect(have).to.be.an("object");
                           expect(have.TODO).to.equal("TODO");
+                          next()
                         })
-                        .finally(next);
                     }
                   );
                 }

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -1066,440 +1066,413 @@ describe('config', function () {
 
 
         /* jshint ignore:start */
-        describe("readPromises()", function() {
-          it("fails on unknown bundle", function(next) {
+        describe('readPromises()', function() {
+          it('fails on unknown bundle', function(next) {
             var config = new Config();
-            config.readPromise("foo", "bar", {}).catch(err => {
+            config.readPromise('foo', 'bar', {}).catch(err => {
               expect(err.message).to.equal('Unknown bundle "foo"');
               next();
             });
           });
 
-          it("fails on unknown config", function(next) {
+          it('fails on unknown config', function(next) {
             var config = new Config();
             config
               .addConfigPromise(
-                "modown-newsboxes",
-                "application",
-                libpath.resolve(mojito, "application.json")
+                'modown-newsboxes',
+                'application',
+                libpath.resolve(mojito, 'application.json')
+              )
+              .then(() => config.readPromise('modown-newsboxes', 'foo', {}))
+              .catch(err => {
+                expect(err.message).to.equal(
+                  'Unknown config "foo" in bundle "modown-newsboxes"'
+                );
+                next();
+              });
+          });
+
+          it('reads non-contextualized .json config files', function(next) {
+            var config = new Config();
+            config
+              .addConfigPromise(
+                'simple',
+                'routes',
+                libpath.resolve(touchdown, 'configs/dimensions.json')
+              )
+              .then(() => config.readPromise('simple', 'routes', {}))
+              .then(have => {
+                expect(have).to.be.an('array');
+                expect(have[0]).to.be.an('object');
+                expect(have[0].dimensions).to.be.an('array');
+                next();
+              });
+          });
+
+          it('reads contextualized .js config files', function(next) {
+            var config = new Config();
+            config
+              .addConfigPromise(
+                'simple',
+                'dimensions',
+                libpath.resolve(touchdown, 'configs/dimensions.json')
               )
               .then(() =>
-                config.readPromise("modown-newsboxes", "foo", {}).catch(err => {
+                config.addConfigPromise(
+                  'simple',
+                  'foo',
+                  libpath.resolve(touchdown, 'configs/foo.js')
+                )
+              )
+              .then(() =>
+                config.readPromise('simple', 'foo', { device: 'mobile' })
+              )
+              .then(have => {
+                expect(have).to.be.an('object');
+                expect(have.TODO).to.equal('TODO');
+                expect(have.selector).to.equal('mobile');
+                next();
+              });
+          });
+
+          it('reads contextualized .json config files', function(next) {
+            var config = new Config();
+            config
+              .addConfigPromise(
+                'modown',
+                'dimensions',
+                libpath.resolve(mojito, 'node_modules/modown/dimensions.json')
+              )
+              .then(() =>
+                config.addConfigPromise(
+                  'modown-newsboxes',
+                  'application',
+                  libpath.resolve(mojito, 'application.json')
+                )
+              )
+              .then(() =>
+                config.readPromise('modown-newsboxes', 'application', {
+                  device: 'mobile'
+                })
+              )
+              .then(have => {
+                expect(have).to.be.an('object');
+                expect(have.TODO).to.equal('TODO');
+                expect(have.selector).to.equal('mobile');
+                next();
+              });
+          });
+
+          it('applies baseContext', function(next) {
+            var config = new Config({
+              baseContext: {
+                device: 'mobile'
+              }
+            });
+            config
+              .addConfigPromise(
+                'modown',
+                'dimensions',
+                libpath.resolve(mojito, 'node_modules/modown/dimensions.json')
+              )
+              .then(() =>
+                config.addConfigPromise(
+                  'modown-newsboxes',
+                  'application',
+                  libpath.resolve(mojito, 'application.json')
+                )
+              )
+              .then(() =>
+                config.readPromise('modown-newsboxes', 'application', {})
+              )
+              .then(have => {
+                expect(have).to.be.an('object');
+                expect(have.TODO).to.equal('TODO');
+                expect(have.selector).to.equal('mobile');
+                next();
+              });
+          });
+
+          it('survives a bad context', function(next) {
+            var config, context;
+            context = { device: 'torture' };
+            config = new Config();
+            config
+              .addConfigPromise(
+                'simple',
+                'dimensions',
+                libpath.resolve(touchdown, 'configs/dimensions.json')
+              )
+              .then(() =>
+                config.addConfigPromise(
+                  'simple',
+                  'foo',
+                  libpath.resolve(touchdown, 'configs/foo.js')
+                )
+              )
+              .then(() =>
+                config.readPromise('simple', 'foo', context).then(have => {
+                  expect(have.selector).to.be.an('undefined');
+                  next();
+                })
+              );
+          });
+
+          it('freezes the config object if the `safeMode` option is passed', function(next) {
+            var config = new Config({
+              safeMode: true
+            });
+            config
+              .addConfigPromise(
+                'simple',
+                'dimensions',
+                libpath.resolve(touchdown, 'configs/dimensions.json')
+              )
+              .then(() =>
+                config.addConfigPromise(
+                  'simple',
+                  'foo',
+                  libpath.resolve(touchdown, 'configs/foo.js')
+                )
+              )
+              .then(() =>
+                config.readPromise('simple', 'foo', { device: 'mobile' })
+              )
+              .then(have => {
+                expect(have).to.be.an('object');
+                expect(have.TODO).to.equal('TODO');
+                next();
+              });
+          });
+        });
+
+        describe('readNoMerge()', function() {
+          it('fails on unknown bundle', function(next) {
+            var config = new Config();
+            config.readNoMergePromise('foo', 'bar', {}).catch(err => {
+              expect(err.message).to.equal('Unknown bundle "foo"');
+              next();
+            });
+          });
+
+          it('fails on unknown config', function(next) {
+            var config = new Config();
+            config
+              .addConfigPromise(
+                'modown-newsboxes',
+                'application',
+                libpath.resolve(mojito, 'application.json')
+              )
+              .then(() =>
+                config.readNoMergePromise('modown-newsboxes', 'foo', {})
+              )
+              .catch(err => {
+                expect(err.message).to.equal(
+                  'Unknown config "foo" in bundle "modown-newsboxes"'
+                );
+                next();
+              });
+          });
+
+          it('reads non-contextualized .json config files', function(next) {
+            var config = new Config();
+            config
+              .addConfigPromise(
+                'simple',
+                'routes',
+                libpath.resolve(touchdown, 'configs/dimensions.json')
+              )
+              .then(() => config.readNoMergePromise('simple', 'routes', {}))
+              .then(have => {
+                expect(have).to.be.an('array');
+                expect(have[0]).to.be.an('array');
+                expect(have[0][0]).to.be.an('object');
+                expect(have[0][0].dimensions).to.be.an('array');
+                next();
+              });
+          });
+
+          it('reads contextualized .js config files', function(next) {
+            var config = new Config();
+            config
+              .addConfigPromise(
+                'simple',
+                'dimensions',
+                libpath.resolve(touchdown, 'configs/dimensions.json')
+              )
+              .then(() =>
+                config.addConfigPromise(
+                  'simple',
+                  'foo',
+                  libpath.resolve(touchdown, 'configs/foo.js')
+                )
+              )
+              .then(() =>
+                config.readNoMergePromise('simple', 'foo', { device: 'mobile' })
+              )
+              .then(have => {
+                expect(have).to.be.an('array');
+                expect(have[0]).to.be.an('object');
+                expect(have[0].TODO).to.equal('TODO');
+                expect(have[1]).to.be.an('object');
+                expect(have[1].selector).to.equal('mobile');
+                next();
+              });
+          });
+
+          it('reads contextualized .json config files', function(next) {
+            var config = new Config();
+            config
+              .addConfigPromise(
+                'modown',
+                'dimensions',
+                libpath.resolve(mojito, 'node_modules/modown/dimensions.json')
+              )
+              .then(() =>
+                config.addConfigPromise(
+                  'modown-newsboxes',
+                  'application',
+                  libpath.resolve(mojito, 'application.json')
+                )
+              )
+              .then(() =>
+                config.readNoMergePromise('modown-newsboxes', 'application', {
+                  device: 'mobile'
+                })
+              )
+              .then(have => {
+                expect(have).to.be.an('array');
+                expect(have[0]).to.be.an('object');
+                expect(have[0].TODO).to.equal('TODO');
+                expect(have[1]).to.be.an('object');
+                expect(have[1].selector).to.equal('mobile');
+                next();
+              });
+          });
+
+          it('applies baseContext', function(next) {
+            var config = new Config({
+              baseContext: {
+                device: 'mobile'
+              }
+            });
+            config
+              .addConfigPromise(
+                'modown',
+                'dimensions',
+                libpath.resolve(mojito, 'node_modules/modown/dimensions.json')
+              )
+              .then(() =>
+                config.addConfigPromise(
+                  'modown-newsboxes',
+                  'application',
+                  libpath.resolve(mojito, 'application.json')
+                )
+              )
+              .then(() =>
+                config.readNoMergePromise('modown-newsboxes', 'application', {})
+              )
+              .then(have => {
+                expect(have).to.be.an('array');
+                expect(have[0]).to.be.an('object');
+                expect(have[0].TODO).to.equal('TODO');
+                expect(have[1]).to.be.an('object');
+                expect(have[1].selector).to.equal('mobile');
+                next();
+              });
+          });
+
+          it('survives a bad context', function(next) {
+            var config, context;
+            context = { device: 'torture' };
+            config = new Config();
+            config
+              .addConfigPromise(
+                'simple',
+                'dimensions',
+                libpath.resolve(touchdown, 'configs/dimensions.json')
+              )
+              .then(() =>
+                config.addConfigPromise(
+                  'simple',
+                  'foo',
+                  libpath.resolve(touchdown, 'configs/foo.js')
+                )
+              )
+              .then(() => config.readNoMergePromise('simple', 'foo', context))
+              .then(have => {
+                expect(have.selector).to.be.an('undefined');
+                next();
+              });
+          });
+
+          it('freezes the config object if the `safeMode` option is passed', function(next) {
+            var config = new Config({
+              safeMode: true
+            });
+            config
+              .addConfigPromise(
+                'simple',
+                'dimensions',
+                libpath.resolve(touchdown, 'configs/dimensions.json')
+              )
+              .then(() =>
+                config.addConfigPromise(
+                  'simple',
+                  'foo',
+                  libpath.resolve(touchdown, 'configs/foo.js')
+                )
+              )
+              .then(() =>
+                config.readNoMergePromise('simple', 'foo', { device: 'mobile' })
+              )
+              .then(have => {
+                expect(have).to.be.an('array');
+                expect(have[0]).to.be.an('object');
+                expect(have[0].TODO).to.equal('TODO');
+                try {
+                  have[0].TODO = 'DONE';
+                } catch (err) {
                   expect(err.message).to.equal(
-                    'Unknown config "foo" in bundle "modown-newsboxes"'
+                    "Cannot assign to read only property 'TODO' of object '#<Object>'"
                   );
                   next();
-                })
-              );
-          });
-
-          it("reads non-contextualized .json config files", function(next) {
-            var config = new Config();
-            config
-              .addConfigPromise(
-                "simple",
-                "routes",
-                libpath.resolve(touchdown, "configs/dimensions.json")
-              )
-              .then(() =>
-                config.readPromise("simple", "routes", {}).then(have => {
-                  expect(have).to.be.an("array");
-                  expect(have[0]).to.be.an("object");
-                  expect(have[0].dimensions).to.be.an("array");
-                  next();
-                })
-              );
-          });
-
-          it("reads contextualized .js config files", function(next) {
-            var config = new Config();
-            config
-              .addConfigPromise(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "simple",
-                    "foo",
-                    libpath.resolve(touchdown, "configs/foo.js")
-                  )
-                  .then(() =>
-                    config
-                      .readPromise("simple", "foo", { device: "mobile" })
-                      .then(have => {
-                        expect(have).to.be.an("object");
-                        expect(have.TODO).to.equal("TODO");
-                        expect(have.selector).to.equal("mobile");
-                        next();
-                      })
-                  )
-              );
-          });
-
-          it("reads contextualized .json config files", function(next) {
-            var config = new Config();
-            config
-              .addConfigPromise(
-                "modown",
-                "dimensions",
-                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "modown-newsboxes",
-                    "application",
-                    libpath.resolve(mojito, "application.json")
-                  )
-                  .then(() =>
-                    config
-                      .readPromise("modown-newsboxes", "application", {
-                        device: "mobile"
-                      })
-                      .then(have => {
-                        expect(have).to.be.an("object");
-                        expect(have.TODO).to.equal("TODO");
-                        expect(have.selector).to.equal("mobile");
-                        next();
-                      })
-                  )
-              );
-          });
-
-          it("applies baseContext", function(next) {
-            var config = new Config({
-              baseContext: {
-                device: "mobile"
-              }
-            });
-            config
-              .addConfigPromise(
-                "modown",
-                "dimensions",
-                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "modown-newsboxes",
-                    "application",
-                    libpath.resolve(mojito, "application.json")
-                  )
-                  .then(() =>
-                    config
-                      .readPromise("modown-newsboxes", "application", {})
-                      .then(have => {
-                        expect(have).to.be.an("object");
-                        expect(have.TODO).to.equal("TODO");
-                        expect(have.selector).to.equal("mobile");
-                        next();
-                      })
-                  )
-              );
-          });
-
-          it("survives a bad context", function(next) {
-            var config, context;
-            context = { device: "torture" };
-            config = new Config();
-            config
-              .addConfigPromise(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "simple",
-                    "foo",
-                    libpath.resolve(touchdown, "configs/foo.js")
-                  )
-                  .then(() =>
-                    config.readPromise("simple", "foo", context).then(have => {
-                      expect(have.selector).to.be.an("undefined");
-                      next();
-                    })
-                  )
-              );
-          });
-
-          it("freezes the config object if the `safeMode` option is passed", function(next) {
-            var config = new Config({
-              safeMode: true
-            });
-            config
-              .addConfigPromise(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "simple",
-                    "foo",
-                    libpath.resolve(touchdown, "configs/foo.js")
-                  )
-                  .then(() =>
-                    config
-                      .readPromise("simple", "foo", { device: "mobile" })
-                      .then(have => {
-                        expect(have).to.be.an("object");
-                        expect(have.TODO).to.equal("TODO");
-                        next();
-                      })
-                  )
-              );
+                }
+              });
           });
         });
 
-        describe("readNoMerge()", function() {
-          it("fails on unknown bundle", function(next) {
-            var config = new Config();
-            config.readNoMergePromise("foo", "bar", {}).catch(err => {
-              expect(err.message).to.equal('Unknown bundle "foo"');
-              next();
-            });
-          });
-
-          it("fails on unknown config", function(next) {
+        describe('readDimensionsPromise()', function() {
+          it('mojito-newsboxes', function(next) {
             var config = new Config();
             config
               .addConfigPromise(
-                "modown-newsboxes",
-                "application",
-                libpath.resolve(mojito, "application.json")
+                'modown',
+                'dimensions',
+                libpath.resolve(mojito, 'node_modules/modown/dimensions.json')
               )
-              .then(() =>
-                config
-                  .readNoMergePromise("modown-newsboxes", "foo", {})
-                  .catch(err => {
-                    expect(err.message).to.equal(
-                      'Unknown config "foo" in bundle "modown-newsboxes"'
-                    );
-                    next();
-                  })
-              );
+              .then(() => config.readDimensionsPromise())
+              .then(dims => {
+                expect(dims).to.be.an('array');
+                expect(dims[0]).to.have.property('runtime');
+                next();
+              });
           });
 
-          it("reads non-contextualized .json config files", function(next) {
+          it('touchdown-simple', function(next) {
             var config = new Config();
             config
               .addConfigPromise(
-                "simple",
-                "routes",
-                libpath.resolve(touchdown, "configs/dimensions.json")
+                'simple',
+                'dimensions',
+                libpath.resolve(touchdown, 'configs/dimensions.json')
               )
-              .then(() =>
-                config.readNoMergePromise("simple", "routes", {}).then(have => {
-                  expect(have).to.be.an("array");
-                  expect(have[0]).to.be.an("array");
-                  expect(have[0][0]).to.be.an("object");
-                  expect(have[0][0].dimensions).to.be.an("array");
-                  next();
-                })
-              );
-          });
-
-          it("reads contextualized .js config files", function(next) {
-            var config = new Config();
-            config
-              .addConfigPromise(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "simple",
-                    "foo",
-                    libpath.resolve(touchdown, "configs/foo.js")
-                  )
-                  .then(() =>
-                    config
-                      .readNoMergePromise("simple", "foo", { device: "mobile" })
-                      .then(have => {
-                        expect(have).to.be.an("array");
-                        expect(have[0]).to.be.an("object");
-                        expect(have[0].TODO).to.equal("TODO");
-                        expect(have[1]).to.be.an("object");
-                        expect(have[1].selector).to.equal("mobile");
-                        next();
-                      })
-                  )
-              );
-          });
-
-          it("reads contextualized .json config files", function(next) {
-            var config = new Config();
-            config
-              .addConfigPromise(
-                "modown",
-                "dimensions",
-                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "modown-newsboxes",
-                    "application",
-                    libpath.resolve(mojito, "application.json")
-                  )
-                  .then(() =>
-                    config
-                      .readNoMergePromise("modown-newsboxes", "application", {
-                        device: "mobile"
-                      })
-                      .then(have => {
-                        expect(have).to.be.an("array");
-                        expect(have[0]).to.be.an("object");
-                        expect(have[0].TODO).to.equal("TODO");
-                        expect(have[1]).to.be.an("object");
-                        expect(have[1].selector).to.equal("mobile");
-                        next();
-                      })
-                  )
-              );
-          });
-
-          it("applies baseContext", function(next) {
-            var config = new Config({
-              baseContext: {
-                device: "mobile"
-              }
-            });
-            config
-              .addConfigPromise(
-                "modown",
-                "dimensions",
-                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "modown-newsboxes",
-                    "application",
-                    libpath.resolve(mojito, "application.json")
-                  )
-                  .then(() =>
-                    config
-                      .readNoMergePromise("modown-newsboxes", "application", {})
-                      .then(have => {
-                        expect(have).to.be.an("array");
-                        expect(have[0]).to.be.an("object");
-                        expect(have[0].TODO).to.equal("TODO");
-                        expect(have[1]).to.be.an("object");
-                        expect(have[1].selector).to.equal("mobile");
-                        next();
-                      })
-                  )
-              );
-          });
-
-          it("survives a bad context", function(next) {
-            var config, context;
-            context = { device: "torture" };
-            config = new Config();
-            config
-              .addConfigPromise(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "simple",
-                    "foo",
-                    libpath.resolve(touchdown, "configs/foo.js")
-                  )
-                  .then(() =>
-                    config
-                      .readNoMergePromise("simple", "foo", context)
-                      .then(have => {
-                        expect(have.selector).to.be.an("undefined");
-                        next();
-                      })
-                  )
-              );
-          });
-
-          it("freezes the config object if the `safeMode` option is passed", function(next) {
-            var config = new Config({
-              safeMode: true
-            });
-            config
-              .addConfigPromise(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json")
-              )
-              .then(() =>
-                config
-                  .addConfigPromise(
-                    "simple",
-                    "foo",
-                    libpath.resolve(touchdown, "configs/foo.js")
-                  )
-                  .then(() =>
-                    config
-                      .readNoMergePromise("simple", "foo", { device: "mobile" })
-                      .then(have => {
-                        expect(have).to.be.an("array");
-                        expect(have[0]).to.be.an("object");
-                        expect(have[0].TODO).to.equal("TODO");
-                        try {
-                          have[0].TODO = "DONE";
-                        } catch (err) {
-                          expect(err.message).to.equal(
-                            "Cannot assign to read only property 'TODO' of object '#<Object>'"
-                          );
-                          next();
-                        }
-                      })
-                  )
-              );
-          });
-        });
-
-        describe("readDimensionsPromise()", function() {
-          it("mojito-newsboxes", function(next) {
-            var config = new Config();
-            config
-              .addConfigPromise(
-                "modown",
-                "dimensions",
-                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
-              )
-              .then(() =>
-                config.readDimensionsPromise().then(dims => {
-                  expect(dims).to.be.an("array");
-                  expect(dims[0]).to.have.property("runtime");
-                  next();
-                })
-              );
-          });
-
-          it("touchdown-simple", function(next) {
-            var config = new Config();
-            config
-              .addConfigPromise(
-                "simple",
-                "dimensions",
-                libpath.resolve(touchdown, "configs/dimensions.json")
-              )
-              .then(() =>
-                config.readDimensionsPromise().then(dims => {
-                  expect(dims).to.be.an("array");
-                  expect(dims[0]).to.have.property("ynet");
-                  next();
-                })
-              );
+              .then(() => config.readDimensionsPromise())
+              .then(dims => {
+                expect(dims).to.be.an('array');
+                expect(dims[0]).to.have.property('ynet');
+                next();
+              });
           });
         });
         /* jshint ignore:end */

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -1077,56 +1077,56 @@ describe('config', function () {
 
           it("fails on unknown config", function(next) {
             var config = new Config();
-            config.addConfig(
-              "modown-newsboxes",
-              "application",
-              libpath.resolve(mojito, "application.json"),
-              function(err) {
+            config
+              .addConfigPromise(
+                "modown-newsboxes",
+                "application",
+                libpath.resolve(mojito, "application.json")
+              )
+              .then(() =>
                 config.readPromise("modown-newsboxes", "foo", {}).catch(err => {
                   expect(err.message).to.equal(
                     'Unknown config "foo" in bundle "modown-newsboxes"'
                   );
                   next();
-                });
-              }
-            );
+                })
+              );
           });
 
           it("reads non-contextualized .json config files", function(next) {
             var config = new Config();
-            config.addConfig(
-              "simple",
-              "routes",
-              libpath.resolve(touchdown, "configs/dimensions.json"),
-              function(err) {
+            config
+              .addConfigPromise(
+                "simple",
+                "routes",
+                libpath.resolve(touchdown, "configs/dimensions.json")
+              )
+              .then(() =>
                 config.readPromise("simple", "routes", {}).then(have => {
                   expect(have).to.be.an("array");
                   expect(have[0]).to.be.an("object");
                   expect(have[0].dimensions).to.be.an("array");
                   next();
-                });
-              }
-            );
+                })
+              );
           });
 
           it("reads contextualized .js config files", function(next) {
             var config = new Config();
-            config.addConfig(
-              "simple",
-              "dimensions",
-              libpath.resolve(touchdown, "configs/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
-                config.addConfig(
-                  "simple",
-                  "foo",
-                  libpath.resolve(touchdown, "configs/foo.js"),
-                  function(err) {
-                    if (err) {
-                      throw err;
-                    }
+            config
+              .addConfigPromise(
+                "simple",
+                "dimensions",
+                libpath.resolve(touchdown, "configs/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "simple",
+                    "foo",
+                    libpath.resolve(touchdown, "configs/foo.js")
+                  )
+                  .then(() =>
                     config
                       .readPromise("simple", "foo", { device: "mobile" })
                       .then(have => {
@@ -1134,31 +1134,27 @@ describe('config', function () {
                         expect(have.TODO).to.equal("TODO");
                         expect(have.selector).to.equal("mobile");
                         next();
-                      });
-                  }
-                );
-              }
-            );
+                      })
+                  )
+              );
           });
 
           it("reads contextualized .json config files", function(next) {
             var config = new Config();
-            config.addConfig(
-              "modown",
-              "dimensions",
-              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
-                config.addConfig(
-                  "modown-newsboxes",
-                  "application",
-                  libpath.resolve(mojito, "application.json"),
-                  function(err) {
-                    if (err) {
-                      throw err;
-                    }
+            config
+              .addConfigPromise(
+                "modown",
+                "dimensions",
+                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "modown-newsboxes",
+                    "application",
+                    libpath.resolve(mojito, "application.json")
+                  )
+                  .then(() =>
                     config
                       .readPromise("modown-newsboxes", "application", {
                         device: "mobile"
@@ -1168,11 +1164,9 @@ describe('config', function () {
                         expect(have.TODO).to.equal("TODO");
                         expect(have.selector).to.equal("mobile");
                         next();
-                      });
-                  }
-                );
-              }
-            );
+                      })
+                  )
+              );
           });
 
           it("applies baseContext", function(next) {
@@ -1181,19 +1175,20 @@ describe('config', function () {
                 device: "mobile"
               }
             });
-            config.addConfig(
-              "modown",
-              "dimensions",
-              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
-              function() {
-                config.addConfig(
-                  "modown-newsboxes",
-                  "application",
-                  libpath.resolve(mojito, "application.json"),
-                  function(err) {
-                    if (err) {
-                      throw err;
-                    }
+            config
+              .addConfigPromise(
+                "modown",
+                "dimensions",
+                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "modown-newsboxes",
+                    "application",
+                    libpath.resolve(mojito, "application.json")
+                  )
+                  .then(() =>
                     config
                       .readPromise("modown-newsboxes", "application", {})
                       .then(have => {
@@ -1201,77 +1196,66 @@ describe('config', function () {
                         expect(have.TODO).to.equal("TODO");
                         expect(have.selector).to.equal("mobile");
                         next();
-                      });
-                  }
-                );
-              }
-            );
+                      })
+                  )
+              );
           });
 
           it("survives a bad context", function(next) {
             var config, context;
             context = { device: "torture" };
             config = new Config();
-            config.addConfig(
-              "simple",
-              "dimensions",
-              libpath.resolve(touchdown, "configs/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
-                config.addConfig(
-                  "simple",
-                  "foo",
-                  libpath.resolve(touchdown, "configs/foo.js"),
-                  function(err) {
-                    if (err) {
-                      throw err;
-                    }
+            config
+              .addConfigPromise(
+                "simple",
+                "dimensions",
+                libpath.resolve(touchdown, "configs/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "simple",
+                    "foo",
+                    libpath.resolve(touchdown, "configs/foo.js")
+                  )
+                  .then(() =>
                     config.readPromise("simple", "foo", context).then(have => {
                       expect(have.selector).to.be.an("undefined");
                       next();
-                    });
-                  }
-                );
-              }
-            );
+                    })
+                  )
+              );
           });
 
           it("freezes the config object if the `safeMode` option is passed", function(next) {
             var config = new Config({
               safeMode: true
             });
-            config.addConfig(
-              "simple",
-              "dimensions",
-              libpath.resolve(touchdown, "configs/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
-                config.addConfig(
-                  "simple",
-                  "foo",
-                  libpath.resolve(touchdown, "configs/foo.js"),
-                  function(err) {
-                    if (err) {
-                      throw err;
-                    }
+            config
+              .addConfigPromise(
+                "simple",
+                "dimensions",
+                libpath.resolve(touchdown, "configs/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "simple",
+                    "foo",
+                    libpath.resolve(touchdown, "configs/foo.js")
+                  )
+                  .then(() =>
                     config
                       .readPromise("simple", "foo", { device: "mobile" })
                       .then(have => {
                         expect(have).to.be.an("object");
                         expect(have.TODO).to.equal("TODO");
                         next();
-                      });
-                  }
-                );
-              }
-            );
+                      })
+                  )
+              );
           });
         });
-
 
         describe("readNoMerge()", function() {
           it("fails on unknown bundle", function(next) {
@@ -1284,14 +1268,13 @@ describe('config', function () {
 
           it("fails on unknown config", function(next) {
             var config = new Config();
-            config.addConfig(
-              "modown-newsboxes",
-              "application",
-              libpath.resolve(mojito, "application.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
+            config
+              .addConfigPromise(
+                "modown-newsboxes",
+                "application",
+                libpath.resolve(mojito, "application.json")
+              )
+              .then(() =>
                 config
                   .readNoMergePromise("modown-newsboxes", "foo", {})
                   .catch(err => {
@@ -1299,47 +1282,45 @@ describe('config', function () {
                       'Unknown config "foo" in bundle "modown-newsboxes"'
                     );
                     next();
-                  });
-              }
-            );
+                  })
+              );
           });
 
           it("reads non-contextualized .json config files", function(next) {
             var config = new Config();
-            config.addConfig(
-              "simple",
-              "routes",
-              libpath.resolve(touchdown, "configs/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
+            config
+              .addConfigPromise(
+                "simple",
+                "routes",
+                libpath.resolve(touchdown, "configs/dimensions.json")
+              )
+              .then(() =>
                 config.readNoMergePromise("simple", "routes", {}).then(have => {
                   expect(have).to.be.an("array");
                   expect(have[0]).to.be.an("array");
                   expect(have[0][0]).to.be.an("object");
                   expect(have[0][0].dimensions).to.be.an("array");
                   next();
-                });
-              }
-            );
+                })
+              );
           });
 
           it("reads contextualized .js config files", function(next) {
             var config = new Config();
-            config.addConfig(
-              "simple",
-              "dimensions",
-              libpath.resolve(touchdown, "configs/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
-                config.addConfig(
-                  "simple",
-                  "foo",
-                  libpath.resolve(touchdown, "configs/foo.js"),
-                  function(err) {
+            config
+              .addConfigPromise(
+                "simple",
+                "dimensions",
+                libpath.resolve(touchdown, "configs/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "simple",
+                    "foo",
+                    libpath.resolve(touchdown, "configs/foo.js")
+                  )
+                  .then(() =>
                     config
                       .readNoMergePromise("simple", "foo", { device: "mobile" })
                       .then(have => {
@@ -1349,31 +1330,27 @@ describe('config', function () {
                         expect(have[1]).to.be.an("object");
                         expect(have[1].selector).to.equal("mobile");
                         next();
-                      });
-                  }
-                );
-              }
-            );
+                      })
+                  )
+              );
           });
 
           it("reads contextualized .json config files", function(next) {
             var config = new Config();
-            config.addConfig(
-              "modown",
-              "dimensions",
-              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
-                config.addConfig(
-                  "modown-newsboxes",
-                  "application",
-                  libpath.resolve(mojito, "application.json"),
-                  function(err) {
-                    if (err) {
-                      throw err;
-                    }
+            config
+              .addConfigPromise(
+                "modown",
+                "dimensions",
+                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "modown-newsboxes",
+                    "application",
+                    libpath.resolve(mojito, "application.json")
+                  )
+                  .then(() =>
                     config
                       .readNoMergePromise("modown-newsboxes", "application", {
                         device: "mobile"
@@ -1385,11 +1362,9 @@ describe('config', function () {
                         expect(have[1]).to.be.an("object");
                         expect(have[1].selector).to.equal("mobile");
                         next();
-                      });
-                  }
-                );
-              }
-            );
+                      })
+                  )
+              );
           });
 
           it("applies baseContext", function(next) {
@@ -1398,22 +1373,20 @@ describe('config', function () {
                 device: "mobile"
               }
             });
-            config.addConfig(
-              "modown",
-              "dimensions",
-              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
-                config.addConfig(
-                  "modown-newsboxes",
-                  "application",
-                  libpath.resolve(mojito, "application.json"),
-                  function(err) {
-                    if (err) {
-                      throw err;
-                    }
+            config
+              .addConfigPromise(
+                "modown",
+                "dimensions",
+                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "modown-newsboxes",
+                    "application",
+                    libpath.resolve(mojito, "application.json")
+                  )
+                  .then(() =>
                     config
                       .readNoMergePromise("modown-newsboxes", "application", {})
                       .then(have => {
@@ -1423,65 +1396,57 @@ describe('config', function () {
                         expect(have[1]).to.be.an("object");
                         expect(have[1].selector).to.equal("mobile");
                         next();
-                      });
-                  }
-                );
-              }
-            );
+                      })
+                  )
+              );
           });
 
           it("survives a bad context", function(next) {
             var config, context;
             context = { device: "torture" };
             config = new Config();
-            config.addConfig(
-              "simple",
-              "dimensions",
-              libpath.resolve(touchdown, "configs/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
-                config.addConfig(
-                  "simple",
-                  "foo",
-                  libpath.resolve(touchdown, "configs/foo.js"),
-                  function(err) {
-                    if (err) {
-                      throw err;
-                    }
+            config
+              .addConfigPromise(
+                "simple",
+                "dimensions",
+                libpath.resolve(touchdown, "configs/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "simple",
+                    "foo",
+                    libpath.resolve(touchdown, "configs/foo.js")
+                  )
+                  .then(() =>
                     config
                       .readNoMergePromise("simple", "foo", context)
                       .then(have => {
                         expect(have.selector).to.be.an("undefined");
                         next();
-                      });
-                  }
-                );
-              }
-            );
+                      })
+                  )
+              );
           });
 
           it("freezes the config object if the `safeMode` option is passed", function(next) {
             var config = new Config({
               safeMode: true
             });
-            config.addConfig(
-              "simple",
-              "dimensions",
-              libpath.resolve(touchdown, "configs/dimensions.json"),
-              function(err) {
-                if (err) {
-                  throw err;
-                }
-                config.addConfig(
-                  "simple",
-                  "foo",
-                  libpath.resolve(touchdown, "configs/foo.js"),
-                  function(err) {
-                    if (err) {
-                      throw err;
-                    }
+            config
+              .addConfigPromise(
+                "simple",
+                "dimensions",
+                libpath.resolve(touchdown, "configs/dimensions.json")
+              )
+              .then(() =>
+                config
+                  .addConfigPromise(
+                    "simple",
+                    "foo",
+                    libpath.resolve(touchdown, "configs/foo.js")
+                  )
+                  .then(() =>
                     config
                       .readNoMergePromise("simple", "foo", { device: "mobile" })
                       .then(have => {
@@ -1496,46 +1461,45 @@ describe('config', function () {
                           );
                           next();
                         }
-                      });
-                  }
-                );
-              }
-            );
+                      })
+                  )
+              );
           });
         });
-
 
         describe("readDimensionsPromise()", function() {
           it("mojito-newsboxes", function(next) {
             var config = new Config();
-            config.addConfig(
-              "modown",
-              "dimensions",
-              libpath.resolve(mojito, "node_modules/modown/dimensions.json"),
-              function(err, data) {
+            config
+              .addConfigPromise(
+                "modown",
+                "dimensions",
+                libpath.resolve(mojito, "node_modules/modown/dimensions.json")
+              )
+              .then(() =>
                 config.readDimensionsPromise().then(dims => {
                   expect(dims).to.be.an("array");
                   expect(dims[0]).to.have.property("runtime");
                   next();
-                });
-              }
-            );
+                })
+              );
           });
 
           it("touchdown-simple", function(next) {
             var config = new Config();
-            config.addConfig(
-              "simple",
-              "dimensions",
-              libpath.resolve(touchdown, "configs/dimensions.json"),
-              function(err, data) {
+            config
+              .addConfigPromise(
+                "simple",
+                "dimensions",
+                libpath.resolve(touchdown, "configs/dimensions.json")
+              )
+              .then(() =>
                 config.readDimensionsPromise().then(dims => {
                   expect(dims).to.be.an("array");
                   expect(dims[0]).to.have.property("ynet");
                   next();
-                });
-              }
-            );
+                })
+              );
           });
         });
         /* jshint ignore:end */

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -1572,8 +1572,6 @@ describe('config', function () {
                 );
             });
         });
-
-
         /* jshint ignore:start */
         describe('promises.read()', function() {
           it('fails on unknown bundle', function(next) {


### PR DESCRIPTION
Per discussion with @redonkulus https://github.com/yahoo/ycb-config/pull/22#issuecomment-568876878, this pull request is point to the new type api of the promised methods.

- `config.promises.read`
- `config.promises.readNoMerge`
- `config.promises.readDimensions`
- `config.promises.addConfig`
- `config.promises.`

~~I'll update these methods in the document later.~~
Document updated 👍 
