### PR TITLE
Fix addConfigContents

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -228,11 +228,11 @@ Config.prototype = {
 
         contents = this._parseConfigContents(fullPath, contents);
 
-        // register so that _readConfigContents() will use
-        self._configContents[fullPath] = contents;
-
         // deregister old config (if any)
         self.deleteConfig(bundleName, configName, fullPath);
+
+        // register so that _readConfigContents() will use
+        self._configContents[fullPath] = contents;
 
         if (!self._configPaths[bundleName]) {
             self._configPaths[bundleName] = {};

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -149,6 +149,21 @@ describe('config', function () {
                     expect(have.color).to.equal('red');
                 });
             });
+            it('should work twice in a row', function () {
+                var config,
+                    object = {color: 'red'};
+                config = new Config();
+                config.addConfigContents('foo', 'bar', 'x.js', object);
+                config.read('foo', 'bar', {}, function(err, have) {
+                    expect(err).to.equal(null);
+                    expect(have.color).to.equal('red');
+                });
+                config.addConfigContents('foo', 'bar', 'x.js', object);
+                config.read('foo', 'bar', {}, function(err, have) {
+                    expect(err).to.equal(null);
+                    expect(have.color).to.equal('red');
+                });
+            });
         });
 
 


### PR DESCRIPTION
@redonkulus 
When adding a new config, deletion of old config should be done prior to any values being set.
Added additional test case.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
