### PR TITLE
handle interrupted ycb fetch

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -564,9 +564,15 @@ Config.prototype = {
     /**
      * Saves a YCB instance for reuse.
      * Checks the config-bundle tags so we don't set it with a stale YCB instance
+     * @param {string} bundleName the bundleName corresponding to the ycb instance
+     * @param {string} configName the configName corresponding to the ycb instance
+     * @param {string} path full path corresponding to the ycb instance
+     * @param {number} groupId the initial id value to check against current value
+     * @param ycb the ycb instance to cache
+     * @private
      */
-    _cacheYCB: function(bundleName, configName, path, tag, ycb) {
-        if(this._configIdMap[bundleName] && this._configIdMap[bundleName][configName] === tag) {
+    _cacheYCB: function(bundleName, configName, path, groupId, ycb) {
+        if(this._configIdMap[bundleName] && this._configIdMap[bundleName][configName] === groupId) {
             this._configYCBs[path] = ycb;
             delete this._configContents[path]; // no longer need to keep a copy of the config
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -248,6 +248,7 @@ Config.prototype = {
         if (!self._configIdMap[bundleName]) {
             self._configIdMap[bundleName] = {};
         }
+
         self._configIdCounter = (self._configIdCounter+1) % Number.MAX_SAFE_INTEGER;
         self._configIdMap[bundleName][configName] = self._configIdCounter;
 
@@ -340,7 +341,7 @@ Config.prototype = {
      */
     read: function (bundleName, configName, context, callback) {
         var self = this;
-        self._getYCB(bundleName, configName, function (err, ycb) {
+        self._getYCB(bundleName, configName, function (err, groupId, ycb) {
             if (err) {
                 callback(err);
                 return;
@@ -348,8 +349,7 @@ Config.prototype = {
             if(self._options.baseContext) {
                 context = self._mergeBaseContext(context);
             }
-            var key, config, groupId;
-            groupId = self._configIdMap[bundleName][configName];
+            var key, config;
             key = self._getCacheKey(bundleName, ':m:', configName, ycb.getCacheKey(context));
             if (self.timeAware) {
                 var now = context[self.timeDimension];
@@ -406,7 +406,7 @@ Config.prototype = {
      */
     readNoMerge: function (bundleName, configName, context, callback) {
         var self = this;
-        self._getYCB(bundleName, configName, function (err, ycb) {
+        self._getYCB(bundleName, configName, function (err, groupId, ycb) {
             if (err) {
                 callback(err);
                 return;
@@ -414,8 +414,7 @@ Config.prototype = {
             if(self._options.baseContext) {
                 context = self._mergeBaseContext(context);
             }
-            var key, config, groupId;
-            groupId = self._configIdMap[bundleName][configName];
+            var key, config;
             key = self._getCacheKey(bundleName, ':um:', configName, ycb.getCacheKey(context));
             if(self.timeAware) {
                 var now = context[self.timeDimension];
@@ -513,8 +512,9 @@ Config.prototype = {
             return callback(new Error(util.format(MESSAGES['unknown config'], configName, bundleName)));
         }
 
+        var groupId = self._configIdMap[bundleName][configName];
         if (self._configYCBs[path]) {
-            return callback(null, self._configYCBs[path]);
+            return callback(null, groupId, self._configYCBs[path]);
         }
 
         self._readConfigContents(path, function (err, contents) {
@@ -532,11 +532,13 @@ Config.prototype = {
 
                     dimensions = data;
                     ycb = self._makeYCBFromDimensions(path, dimensions, contents);
-                    callback(null, ycb);
+                    self._cacheYCB(bundleName, configName, path, groupId, ycb);
+                    callback(null, groupId, ycb);
                 });
             } else {
                 ycb = self._makeYCBFromDimensions(path, dimensions, contents);
-                callback(null, ycb);
+                self._cacheYCB(bundleName, configName, path, groupId, ycb);
+                callback(null, groupId, ycb);
             }
         });
     },
@@ -556,9 +558,18 @@ Config.prototype = {
         } else {
             ycb = makeFakeYCB(dimensions, contents);
         }
-        this._configYCBs[path] = ycb;
-        delete this._configContents[path]; // no longer need to keep a copy of the config
         return ycb;
+    },
+
+    /**
+     * Saves a YCB instance for reuse.
+     * Checks the config-bundle tags so we don't set it with a stale YCB instance
+     */
+    _cacheYCB: function(bundleName, configName, path, tag, ycb) {
+        if(this._configIdMap[bundleName] && this._configIdMap[bundleName][configName] === tag) {
+            this._configYCBs[path] = ycb;
+            delete this._configContents[path]; // no longer need to keep a copy of the config
+        }
     },
 
     /**

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -166,7 +166,7 @@ describe('config', function () {
             });
             it('should not set stale ycb', function (done) {
                 var ycbConfig = new Config({
-                    dimensionsPath: '/Users/bdorn/ycb_config_master/example-dimension.json',
+                    dimensionsPath: libpath.resolve(fixtures, 'touchdown-simple/configs/dimensions.json')
                 });
                 var bundleName = 'bundle';
                 var configName = 'config';

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -164,6 +164,31 @@ describe('config', function () {
                     expect(have.color).to.equal('red');
                 });
             });
+            it('should not set stale ycb', function (done) {
+                var ycbConfig = new Config({
+                    dimensionsPath: '/Users/bdorn/ycb_config_master/example-dimension.json',
+                });
+                var bundleName = 'bundle';
+                var configName = 'config';
+
+                var config1 = [{'settings':['master'],'msg':'FIRST'}];
+                var config2 = [{'settings':['master'],'msg':'SECOND'}];
+
+                ycbConfig.addConfigContents(bundleName, configName, 'example-config.json', config1, function(err, config) {
+                    ycbConfig.read(bundleName, configName, {}, function(err, config) {
+                        expect(err).to.equal(null);
+                        expect(config.msg).to.equal('FIRST');
+                    });
+                });
+                ycbConfig.addConfigContents(bundleName, configName, 'example-config.json', config2, function(err, config) {});
+                setTimeout(function () {
+                    ycbConfig.read(bundleName, configName, {}, function(err, config) {
+                        expect(err).to.equal(null);
+                        expect(config.msg).to.equal('SECOND');
+                        done();
+                    });
+                }, 100);
+            });
         });
 
 

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -1473,7 +1473,7 @@ describe('config', function () {
         describe('_getYCB()', function () {
             it('fails on unknown bundle', function (next) {
                 var config = new Config();
-                config._getYCB('foo', 'bar', function (err, ycb) {
+                config._getYCB('foo', 'bar', function (err, tag, ycb) {
                     try {
                         expect(err.message).to.equal('Unknown bundle "foo"');
                         next();
@@ -1491,7 +1491,7 @@ describe('config', function () {
                     libpath.resolve(mojito, 'application.json'),
                     function (err) {
                         if (err) { throw err; }
-                        config._getYCB('modown-newsboxes', 'foo', function (err, have) {
+                        config._getYCB('modown-newsboxes', 'foo', function (err, tag, have) {
                             try {
                                 expect(err.message).to.equal('Unknown config "foo" in bundle "modown-newsboxes"');
                                 next();
@@ -1510,7 +1510,7 @@ describe('config', function () {
                     'routes',
                     libpath.resolve(touchdown, 'configs/dimensions.json'),
                     function (err) {
-                        config._getYCB('simple', 'routes', function (err, ycb) {
+                        config._getYCB('simple', 'routes', function (err, tag, ycb) {
                             var have = ycb.read({});
                             try {
                                 expect(have).to.be.an('array');
@@ -1538,7 +1538,7 @@ describe('config', function () {
                             'foo',
                             libpath.resolve(touchdown, 'configs/foo.js'),
                             function (err) {
-                                config._getYCB('simple', 'foo', function (err, ycb) {
+                                config._getYCB('simple', 'foo', function (err, tag, ycb) {
                                     var have;
                                     try {
                                         have = ycb.read({device: 'mobile'});
@@ -1569,7 +1569,7 @@ describe('config', function () {
                             'application',
                             libpath.resolve(mojito, 'application.json'),
                             function (err) {
-                                config._getYCB('modown-newsboxes', 'application', function (err, ycb) {
+                                config._getYCB('modown-newsboxes', 'application', function (err, tag, ycb) {
                                     var have;
                                     try {
                                         have = ycb.read({device: 'mobile'});


### PR DESCRIPTION
@redonkulus 
`_getYCB` may make `fs` call due to unloaded dimensions, to prevent saving a stale ycb instance we compare the groupId from before and after the possible async call.

 ---
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
