### PR TITLE
feat: add support for es modules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,19 @@ function clone(o) {
     return JSON.parse(JSON.stringify(o));
 }
 
+/**
+ * Require the export of a CJS module or default export of an ESModule
+ * @param {String} id module name or path
+ * @returns {*} exported module content
+ */
+function interopRequireDefault(id) {
+    var obj = require(id);
+    if (obj.__esModule) {
+        return obj.default;
+    }
+    return obj;
+}
+
 function mix(target, source, overwrite) {
     var prop;
     for (prop in source) {
@@ -614,7 +627,7 @@ Config.prototype = {
             });
         } else {
             try {
-                contents = require(path);
+                contents = interopRequireDefault(path);
             } catch (e) {
                 return callback(new Error(util.format(MESSAGES['parse error'], path, e.message)));
             }
@@ -636,7 +649,7 @@ Config.prototype = {
                 } else if ('.json5' === ext) {
                     contents = libjson5.parse(contents);
                 } else if ('.js' === ext) {
-                    contents = require(path);
+                    contents = interopRequireDefault(path);
                 } else {
                     contents = libyaml.parse(contents);
                 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,6 +17,7 @@ var libfs       = require('fs'),
     libcache    = require('./cache'),
     deepFreeze  = require('deep-freeze'),
     promisify   = require('util').promisify,
+    mjs         = require('./mjs'),
 
     MESSAGES = {
         'unknown bundle': 'Unknown bundle "%s"',
@@ -35,7 +36,7 @@ function clone(o) {
 }
 
 /**
- * Require the export of a CJS module or default export of an ESModule
+ * Require the export of a CJS module or default export of a transpiled ESModule
  * @param {String} id module name or path
  * @returns {*} exported module content
  */
@@ -45,6 +46,24 @@ function interopRequireDefault(id) {
         return obj.default;
     }
     return obj;
+}
+
+/**
+ * Import an untranspiled ES Module
+ * @param {String} id module name or path
+ * @param {Function} [callback] Called once the config has been added to the helper.
+ *   @param {Error|null} callback.err If an error occurred, then this parameter will
+ *   contain the error. If the operation succeeded, then `err` will be null.
+ *   @param {Object} callback.contents The contents of the config file, as a
+ *   JavaScript object.
+ */
+function importMjs(id, callback) {
+    mjs(id, function (err, obj) {
+        if (err) {
+            return callback(new Error(util.format(MESSAGES['parse error'], id, err.message)));
+        }
+        callback(null, obj.default);
+    });
 }
 
 function mix(target, source, overwrite) {
@@ -625,6 +644,8 @@ Config.prototype = {
                     return callback(err, contents);
                 });
             });
+        } else if (ext === '.mjs') {
+            return importMjs(path, callback);
         } else {
             try {
                 contents = interopRequireDefault(path);
@@ -648,6 +669,8 @@ Config.prototype = {
                     contents = JSON.parse(contents);
                 } else if ('.json5' === ext) {
                     contents = libjson5.parse(contents);
+                } else if ('.mjs' === ext) {
+                    return importMjs(path, callback);
                 } else if ('.js' === ext) {
                     contents = interopRequireDefault(path);
                 } else {

--- a/lib/mjs/index.js
+++ b/lib/mjs/index.js
@@ -1,0 +1,12 @@
+const path = require('path');
+const version = parseInt(process.versions.node.split('.'), 10);
+const id = path.resolve(__dirname, version >= 8 ? 'modern' : 'legacy');
+
+/**
+ * Older versions of node will throw a syntax error when it sees `import`
+ * Since this library supports down to Node 0.8, we need to dynamically
+ * route importing of mjs files to a NOOP that throws an error for legacy
+ * versions of Node and does the actual import for newer versions.
+ * https://nodejs.org/api/esm.html#esm_import_expressions
+ */
+module.exports = require(id);

--- a/lib/mjs/index.js
+++ b/lib/mjs/index.js
@@ -1,6 +1,6 @@
-const path = require('path');
-const version = parseInt(process.versions.node.split('.'), 10);
-const id = path.resolve(__dirname, version >= 8 ? 'modern' : 'legacy');
+var path = require('path');
+var version = parseInt(process.versions.node.split('.'), 10);
+var id = path.resolve(__dirname, version >= 12 ? 'modern' : 'legacy');
 
 /**
  * Older versions of node will throw a syntax error when it sees `import`

--- a/lib/mjs/legacy.js
+++ b/lib/mjs/legacy.js
@@ -1,3 +1,3 @@
 module.exports = function(id, callback) {
-    return callback(new Error('Node >= 8 is required to import .mjs file'));
+    return callback(new Error('Node >= 12 is required to import .mjs file'));
 }

--- a/lib/mjs/legacy.js
+++ b/lib/mjs/legacy.js
@@ -1,0 +1,3 @@
+module.exports = function(id, callback) {
+    return callback(new Error('Node >= 8 is required to import .mjs file'));
+}

--- a/lib/mjs/modern.js
+++ b/lib/mjs/modern.js
@@ -1,0 +1,7 @@
+module.exports = function(id, callback) {
+    import(id).then(function (obj) {
+        callback(null, obj);
+    }).catch(function (e) {
+        return callback(e);
+    });
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ycb-config",
-    "version": "2.1.4",
+    "version": "2.2.0",
     "description": "Configuration manager for Yahoo configuration bundles",
     "author": "Drew Folta <folta@yahoo-inc.com>",
     "contributors": [],

--- a/tests/fixtures/touchdown-simple/configs/esm.js
+++ b/tests/fixtures/touchdown-simple/configs/esm.js
@@ -1,0 +1,12 @@
+module.exports.default = [
+    {
+        settings: [ 'master' ],
+        foo: 'bar'
+    },
+    {
+        settings: [ 'device:mobile' ],
+        foo: 'baz'
+    }
+];
+
+module.exports.__esModule = true;

--- a/tests/fixtures/touchdown-simple/configs/transpiled-esm.js
+++ b/tests/fixtures/touchdown-simple/configs/transpiled-esm.js
@@ -1,11 +1,8 @@
 module.exports.default = [
     {
         settings: [ 'master' ],
-        foo: 'bar'
-    },
-    {
-        settings: [ 'device:mobile' ],
-        foo: 'baz'
+        syntax: 'esm',
+        transpiled: true
     }
 ];
 

--- a/tests/fixtures/touchdown-simple/configs/untranspiled-esm.mjs
+++ b/tests/fixtures/touchdown-simple/configs/untranspiled-esm.mjs
@@ -1,0 +1,7 @@
+export default [
+    {
+        settings: [ 'master' ],
+        syntax: 'esm',
+        transpiled: false
+    }
+];

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -315,6 +315,27 @@ describe('config', function () {
             });
         });
 
+        describe('ES Modules', function () {
+            it('should use the default export of an ES Module', function (next) {
+                var config,
+                    path;
+                config = new Config();
+                path = libpath.resolve(touchdown, 'configs/esm.js');
+                config._readConfigContents(path, function (err, have) {
+                    var want = [
+                        { settings: [ 'master' ], foo: 'bar' },
+                        { settings: [ 'device:mobile' ], foo: 'baz' }
+                    ];
+                    try {
+                        compareObjects(have, want);
+                        next();
+                    } catch (err) {
+                        next(err);
+                    }
+                });
+            });
+        });
+
         describe('makeYCB()', function () {
             it('should not error on undefined contents', function () {
                 var dimensions = [{foo: 'f'}, {settings: ['master']}];

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -339,23 +339,30 @@ describe('config', function () {
             });
 
             it('should use the default export of an untranspiled ES Module', function (next) {
+                var version = parseInt(process.versions.node.split('.'), 10);
                 var config,
                     path;
                 config = new Config();
                 path = libpath.resolve(touchdown, 'configs/untranspiled-esm.mjs');
                 config._readConfigContents(path, function (err, have) {
-                    var want = [
-                        {
-                            settings: [ 'master' ],
-                            syntax: 'esm',
-                            transpiled: false
+                    if (version >= 12) {
+                        var want = [
+                            {
+                                settings: [ 'master' ],
+                                syntax: 'esm',
+                                transpiled: false
+                            }
+                        ];
+                        try {
+                            compareObjects(have, want);
+                            next();
+                        } catch (err) {
+                            next(err);
                         }
-                    ];
-                    try {
-                        compareObjects(have, want);
+                    } else {
+                        expect(err).to.be.an('error');
+                        expect(err.message).to.include('Node >= 12 is required to import .mjs file');
                         next();
-                    } catch (err) {
-                        next(err);
                     }
                 });
             });

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -316,15 +316,40 @@ describe('config', function () {
         });
 
         describe('ES Modules', function () {
-            it('should use the default export of an ES Module', function (next) {
+            it('should use the default export of a transpiled ES Module', function (next) {
                 var config,
                     path;
                 config = new Config();
-                path = libpath.resolve(touchdown, 'configs/esm.js');
+                path = libpath.resolve(touchdown, 'configs/transpiled-esm.js');
                 config._readConfigContents(path, function (err, have) {
                     var want = [
-                        { settings: [ 'master' ], foo: 'bar' },
-                        { settings: [ 'device:mobile' ], foo: 'baz' }
+                        {
+                            settings: [ 'master' ], 
+                            syntax: 'esm',
+                            transpiled: true
+                        }
+                    ];
+                    try {
+                        compareObjects(have, want);
+                        next();
+                    } catch (err) {
+                        next(err);
+                    }
+                });
+            });
+
+            it('should use the default export of an untranspiled ES Module', function (next) {
+                var config,
+                    path;
+                config = new Config();
+                path = libpath.resolve(touchdown, 'configs/untranspiled-esm.mjs');
+                config._readConfigContents(path, function (err, have) {
+                    var want = [
+                        {
+                            settings: [ 'master' ],
+                            syntax: 'esm',
+                            transpiled: false
+                        }
                     ];
                     try {
                         compareObjects(have, want);


### PR DESCRIPTION
This PR allows the use of an config that is either ESM or CJS by dereferencing the default export of an ES Module.

1. For ESM that is transpiled to CJS, the convention is to add a decorative field, `__esModule: true` to the module's exports - see examples for [typescript](https://www.typescriptlang.org/play?target=7&module=1#code/KYDwDg9gTgLgBAE2AMwIYFcA28DaBvAWACg5EBLAW2ADsBnMiOgLjn2NNKQDcyBjYFoRIdOwWgGsYEMC2pZM7DgF9FSgLrF1QA) and [babel](https://babeljs.io/repl/#?browsers=defaults&build=&builtIns=usage&corejs=3.6&spec=true&loose=true&code_lz=KYDwDg9gTgLgBAE2AMwIYFcA28DaBvAKDkQEsBbYAOwGcSIaAuOfI4xYANxIGNgnC2bJNQDWMCGCaUsmVsQC-reQF0CKoA&debug=false&forceAllTransforms=true&shippedProposals=true&circleciRepo=&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=false&presets=env&prettier=false&targets=&version=7.14.3&externalPlugins=babel-plugin-transform-export-extensions%406.22.0%2C%40babel%2Fplugin-proposal-export-default%407.0.0-beta.32)
2. For modules that retain the ESM syntax, they should have the `.mjs` file extension and can be `import`ed  per the [node api](https://nodejs.org/api/esm.html)

I'm really more concerned about the first use case, though it seemed easy enough to tackle the second use case while I was here. The only issue with the second use case is that the `import` syntax will throw in legacy, already EOL'd versions of node so I had to add a wrapper around that which will protect older node versions. I'm totally okay with removing the `mjs` functionality if that's more palatable. 

-----

Alternatively this can be done in userland by using `.addConfigContents` and passing the exported module, too.

-----

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
