### PR TITLE
feat: pass current time by default

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -340,13 +340,7 @@ Config.prototype = {
             var key, config;
             key = self._getCacheKey(bundleName, ':m:', configName, ycb.getCacheKey(context));
             if (self.timeAware) {
-                var now = context[self.timeDimension];
-                if (now === undefined) {
-                    callback(
-                        new Error(util.format(MESSAGES['missing time'], self.timeDimension, JSON.stringify(context)))
-                    );
-                    return;
-                }
+                var now = context[self.timeDimension] || Date.now();
                 config = self._cache.getTimeAware(key, now, groupId);
                 if (config === undefined) {
                     config = ycb.readTimeAware(context, now, { cacheInfo: true });

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -4,5 +4,4 @@ module.exports = {
     'unknown cache data': 'Unknown cache data with config "%s" in bundle "%s"',
     'missing dimensions': 'Failed to find a dimensions.json file',
     'parse error': 'Failed to parse "%s"\n%s',
-    'missing time': 'No time dimension, %s, in context, %s, during time aware mode',
 };

--- a/lib/mod/modern.js
+++ b/lib/mod/modern.js
@@ -15,7 +15,7 @@ module.exports = async (id, callback) => {
     // that for ESM files, we can at least not break CJS by adding a first try to require
     // the file which will then fail over to the ESM compatible import should that fail.
     try {
-        const mod = require(id);
+        const mod = interopDefault(require(id));
         callback(null, mod);
         return;
     } catch (e) {

--- a/lib/mod/modern.js
+++ b/lib/mod/modern.js
@@ -10,6 +10,18 @@ const { interopDefault, ParseError } = require('./utils');
  *   JavaScript object.
  */
 module.exports = async (id, callback) => {
+    // Until https://github.com/facebook/jest/issues/9430 is solved, we can't use import
+    // in this library as it will break anyone using Jest. While there is no way around
+    // that for ESM files, we can at least not break CJS by adding a first try to require
+    // the file which will then fail over to the ESM compatible import should that fail.
+    try {
+        const mod = require(id);
+        callback(null, mod);
+        return;
+    } catch (e) {
+        // do nothing
+    }
+
     try {
         const mod = interopDefault(await import(id));
         callback(null, mod.default);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ycb-config",
-    "version": "2.3.0-beta.3",
+    "version": "2.3.0",
     "description": "Configuration manager for Yahoo configuration bundles",
     "author": "Drew Folta <folta@yahoo-inc.com>",
     "contributors": [],

--- a/package.json
+++ b/package.json
@@ -13,16 +13,17 @@
     },
     "homepage": "https://github.com/yahoo/ycb-config",
     "dependencies": {
-        "ycb": "^2.2.0",
+        "deep-freeze": "~0.0.1",
         "json5": "^2.2.1",
         "yamljs": "^0.3.0",
-        "deep-freeze": "~0.0.1"
+        "ycb": "^2.2.0"
     },
     "devDependencies": {
         "chai": "^4.3.6",
-        "eslint": "^8.21.0",
+        "eslint": "^8.23.1",
         "mocha": "^10.0.0",
-        "prettier": "^2.7.1"
+        "prettier": "^2.7.1",
+        "sinon": "^14.0.0"
     },
     "scripts": {
         "lint": "eslint lib/*.js tests/lib/*.js && prettier --check .",

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -11,6 +11,7 @@ var libpath = require('path'),
     expect = require('chai').expect,
     assert = require('chai').assert,
     Config = require('../../lib/index'),
+    sinon = require('sinon'),
     fixtures = libpath.resolve(__dirname, '../fixtures/');
 
 // expect().to.deep.equal() cares about order of keys
@@ -1220,6 +1221,41 @@ describe('config', function () {
                                         next();
                                     }
                                 );
+                            }
+                        );
+                    }
+                );
+            });
+
+            it('should pass the current time by default', function (next) {
+                var currentTime = new Date('2010-01-01').getTime();
+                var clock = sinon.useFakeTimers(currentTime);
+                var config = new Config({ timeAware: true });
+                config.addConfig(
+                    'simple',
+                    'dimensions',
+                    libpath.resolve(touchdown, 'configs/dimensions.json'),
+                    function (err) {
+                        if (err) {
+                            throw err;
+                        }
+                        config.addConfig(
+                            'simple',
+                            'foo',
+                            libpath.resolve(touchdown, 'configs/no-main.js'),
+                            function (err) {
+                                if (err) {
+                                    throw err;
+                                }
+                                config.read('simple', 'foo', { device: 'mobile' }, function (err, have) {
+                                    if (err) {
+                                        throw err;
+                                    }
+                                    clock.restore();
+                                    expect(have).to.be.an('object');
+                                    expect(have.name).to.equal('old');
+                                    next();
+                                });
                             }
                         );
                     }


### PR DESCRIPTION
This PR passes the current time by default IFF the `timeAware` config is truthy. No changes for folks who have not opted-into `timeAware`.

Previously we would throw an error if the time context was not set, but seeing how it seems likely that the majority use case would be to use the current time, this functionality seems more sensible.

-----

We've also been maintaining a pre-release version for a long time now under the assumption that https://github.com/facebook/jest/issues/9430 would have been resolved. That has taken far longer than expected and appears as if it might take several more months, unfortunately.

While `import` is fully capable of handling CJS code, I'm adding a `require` for CJS so that we can get off of the pre-release version, finally. Once the above issue is fixed, we can remove that code, but I think this is the best we can do for now.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
