### PR TITLE
refactor: remove stale dependency deep-freeze

### DIFF
--- a/lib/deep.js
+++ b/lib/deep.js
@@ -1,14 +1,16 @@
-module.exports = function deepFreeze (o) {
+module.exports = function deepFreeze(o) {
     Object.freeze(o);
 
     Object.getOwnPropertyNames(o).forEach(function (prop) {
-        if (o.hasOwnProperty(prop)
-    && o[prop] !== null
-    && (typeof o[prop] === "object" || typeof o[prop] === "function")
-    && !Object.isFrozen(o[prop])) {
+        if (
+            o.hasOwnProperty(prop) &&
+            o[prop] !== null &&
+            (typeof o[prop] === 'object' || typeof o[prop] === 'function') &&
+            !Object.isFrozen(o[prop])
+        ) {
             deepFreeze(o[prop]);
         }
     });
-  
+
     return o;
 };

--- a/lib/deep.js
+++ b/lib/deep.js
@@ -1,0 +1,14 @@
+module.exports = function deepFreeze (o) {
+    Object.freeze(o);
+
+    Object.getOwnPropertyNames(o).forEach(function (prop) {
+        if (o.hasOwnProperty(prop)
+    && o[prop] !== null
+    && (typeof o[prop] === "object" || typeof o[prop] === "function")
+    && !Object.isFrozen(o[prop])) {
+            deepFreeze(o[prop]);
+        }
+    });
+  
+    return o;
+};

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     },
     "homepage": "https://github.com/yahoo/ycb-config",
     "dependencies": {
-        "deep-freeze": "~0.0.1",
         "json5": "^2.2.1",
         "yamljs": "^0.3.0",
         "ycb": "^2.2.0"

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     },
     "scripts": {
         "lint": "eslint lib/*.js tests/lib/*.js && prettier --check .",
-        "test": "mocha tests/lib/index.js tests/lib/cache-test.js --reporter spec"
+        "test": "mocha tests/lib/index.js tests/lib/cache-test.js tests/lib/deep.js --reporter spec"
     },
     "license": "BSD",
     "repository": {

--- a/tests/lib/deep.js
+++ b/tests/lib/deep.js
@@ -1,0 +1,13 @@
+var test = require('tap').test;
+var deepFreeze = require('../');
+
+test('deep freeze', function (t) {
+    t.plan(2);
+    
+    deepFreeze(Buffer);
+    Buffer.x = 5;
+    t.equal(Buffer.x, undefined);
+    
+    Buffer.prototype.z = 3;
+    t.equal(Buffer.prototype.z, undefined);
+});

--- a/tests/lib/deep.js
+++ b/tests/lib/deep.js
@@ -1,13 +1,27 @@
-var test = require('tap').test;
-var deepFreeze = require('../');
+'use strict';
 
-test('deep freeze', function (t) {
-    t.plan(2);
-    
-    deepFreeze(Buffer);
-    Buffer.x = 5;
-    t.equal(Buffer.x, undefined);
-    
-    Buffer.prototype.z = 3;
-    t.equal(Buffer.prototype.z, undefined);
+var expect = require('chai').expect,
+    deepFreeze = require('../../lib/deep');
+
+function assertImmutableObject (object, modifier) {
+    var catchedErr = null;
+    try {
+        modifier(object);
+    } catch (err) {
+        catchedErr = err;
+    }
+    expect(catchedErr).to.be.an['instanceof'](Error);
+    expect(catchedErr.message).to.include('object is not extensible');
+}
+
+describe('deep freeze', function () {
+    it('should be immutable', function () {
+        deepFreeze(Buffer);
+        assertImmutableObject(Buffer, function (obj) {
+            obj.x = 5;
+        });
+        assertImmutableObject(Buffer, function (obj) {
+            obj.prototype.z = 3;
+        });
+    });
 });

--- a/tests/lib/deep.js
+++ b/tests/lib/deep.js
@@ -3,7 +3,7 @@
 var expect = require('chai').expect,
     deepFreeze = require('../../lib/deep');
 
-function assertImmutableObject (object, modifier) {
+function assertImmutableObject(object, modifier) {
     var catchedErr = null;
     try {
         modifier(object);


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

--------

## Goal

Hi team, I notice one of your dependency `deep-freeze` has been stale for more than 10 years and even its repo was deleted.

- https://www.npmjs.com/package/deep-freeze
- https://github.com/substack/deep-freeze


