### PR TITLE
feat: clone cached configuration before returning it

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -6,6 +6,39 @@
 
 'use strict';
 
+function isA(item, constructor) {
+    return item && item.constructor === constructor;
+}
+
+/**
+ * Performs a safe deep clone of an object
+ * @param {object} o The object to be cloned
+ * @return {object} the cloned object
+ */
+function cloneDeep(o) {
+    var newO;
+
+    if (!o || typeof o !== 'object') {
+        return o;
+    }
+
+    if (isA(o, Array)) {
+        newO = [];
+        for (var i = 0, j = o.length; i < j; i += 1) {
+            newO[i] = cloneDeep(o[i]);
+        }
+        return newO;
+    }
+
+    newO = {};
+    for (i in o) {
+        if (o.hasOwnProperty(i)) {
+            newO[i] = cloneDeep(o[i]);
+        }
+    }
+    return newO;
+}
+
 /**
  * Entry class used as map values and intrusive linked list nodes.
  */
@@ -107,7 +140,7 @@ ConfigCache.prototype = {
                 return undefined; //do not clean up stale entry as we know client code will set this key
             }
             this._makeYoungest(entry);
-            return entry.value;
+            return cloneDeep(entry.value);
         }
         return undefined;
     },
@@ -126,7 +159,7 @@ ConfigCache.prototype = {
                 return undefined; //do not clean up stale entry as we know client code will set this key
             }
             this._makeYoungest(entry);
-            return entry.value;
+            return cloneDeep(entry.value);
         }
         return undefined;
     },

--- a/lib/index.js
+++ b/lib/index.js
@@ -314,8 +314,6 @@ Config.prototype = {
      * Reads the contents of the named configuration file.
      * This will auto-detect if the configuration file is YCB and read it in a context-sensitive way if so.
      *
-     * This can possibly return the configuration object that is stored in a cache, so the caller should
-     * copy it if they intend to make a modifications.
      * @method read
      * @async
      * @param {string} bundleName The bundle in which to find the configuration file.
@@ -374,8 +372,6 @@ Config.prototype = {
      *
      * If the file is not context sensitive then the list will contain a single section.
      *
-     * This can possibly return the configuration object that is stored in a cache, so the caller should
-     * copy it if they intend to make a modifications.
      * @method readNoMerge
      * @async
      * @param {string} bundleName The bundle in which to find the configuration file.
@@ -497,7 +493,7 @@ Config.prototype = {
 
         var groupId = self._configIdMap[bundleName][configName];
         if (self._configYCBs[path]) {
-            return callback(null, groupId, Object.assign({}, self._configYCBs[path]));
+            return callback(null, groupId, self._configYCBs[path]);
         }
 
         self._readConfigContents(path, function (err, contents) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -497,7 +497,7 @@ Config.prototype = {
 
         var groupId = self._configIdMap[bundleName][configName];
         if (self._configYCBs[path]) {
-            return callback(null, groupId, self._configYCBs[path]);
+            return callback(null, groupId, Object.assign({}, self._configYCBs[path]));
         }
 
         self._readConfigContents(path, function (err, contents) {

--- a/tests/lib/cache-test.js
+++ b/tests/lib/cache-test.js
@@ -280,4 +280,59 @@ describe('cache', function () {
             validateCacheStructure(cache);
         });
     });
+
+    describe('immutability', function () {
+        var foo, cache;
+
+        this.beforeEach(function () {
+            cache = new LRU();
+            foo = {
+                a: '1',
+                b: {
+                    c: 2,
+                },
+            };
+        });
+
+        it('should return a different object than the one stored in cache', function () {
+            cache.set('foo', foo, 1);
+
+            var cachedFoo = cache.get('foo', 1);
+
+            expect(cachedFoo).to.not.equal(foo);
+        });
+
+        it('should return a different object than the one stored in cache time aware', function () {
+            cache.setTimeAware('foo', foo, 10, 1000, 1);
+
+            var cachedFoo = cache.getTimeAware('foo', 500, 1);
+
+            expect(cachedFoo).to.not.equal(foo);
+        });
+
+        it('should return an object from cache equivalent to the original', function () {
+            cache.set('foo', foo, 1);
+
+            var cachedFoo = cache.get('foo', 1);
+
+            expect(cachedFoo).to.deep.equal(foo);
+        });
+
+        it('should return an object from cache equivalent to the original time aware', function () {
+            cache.setTimeAware('foo', foo, 10, 1000, 1);
+
+            var cachedFoo = cache.getTimeAware('foo', 500, 1);
+
+            expect(cachedFoo).to.deep.equal(foo);
+        });
+
+        it('should perform a deep clone', function () {
+            cache.set('foo', foo, 1);
+
+            var cachedFoo = cache.get('foo', 1);
+
+            expect(cachedFoo.b).to.not.equal(foo.b);
+            expect(cachedFoo.b).to.deep.equal(foo.b);
+        });
+    });
 });


### PR DESCRIPTION
I've checked that it could be very easy to unintentionally modify a cached YCB configuration (for example, merging it with another source of information). Subsequents access to the same YCB configuration will wrongly receive the mutated object.

I opened a Draft PR to propose making the cache immutable. `Object.assign` is usually the most performant way to deep clone objects across Javascrip runtimes: https://jsben.ch/P8MHg

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.


