### PR TITLE
feat: support .cjs extension

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -604,6 +604,8 @@ Config.prototype = {
                     contents = libjson5.parse(contents);
                 } else if ('.mjs' === ext || '.js' === ext) {
                     return loadModule(path, callback);
+                } else if ('.cjs' === ext) {
+                    contents = require(path);
                 } else {
                     contents = libyaml.parse(contents);
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ycb-config",
-    "version": "2.3.0",
+    "version": "2.4.0",
     "description": "Configuration manager for Yahoo configuration bundles",
     "author": "Drew Folta <folta@yahoo-inc.com>",
     "contributors": [],
@@ -13,16 +13,16 @@
     },
     "homepage": "https://github.com/yahoo/ycb-config",
     "dependencies": {
-        "json5": "^2.2.1",
+        "json5": "^2.2.3",
         "yamljs": "^0.3.0",
         "ycb": "^2.2.0"
     },
     "devDependencies": {
-        "chai": "^4.3.6",
-        "eslint": "^8.23.1",
-        "mocha": "^10.0.0",
+        "chai": "^4.3.7",
+        "eslint": "^8.44.0",
+        "mocha": "^10.2.0",
         "prettier": "^3.0.0",
-        "sinon": "^15.0.0"
+        "sinon": "^15.2.0"
     },
     "scripts": {
         "lint": "eslint lib/*.js tests/lib/*.js && prettier --check .",

--- a/tests/fixtures/touchdown-simple/configs/commonjs.cjs
+++ b/tests/fixtures/touchdown-simple/configs/commonjs.cjs
@@ -1,0 +1,7 @@
+module.exports = [
+    {
+        settings: ['main'],
+        syntax: 'cjs',
+        transpiled: false
+    }
+];

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -153,6 +153,22 @@ describe('config', function () {
                     });
                 });
             });
+            it('reads .cjs config files', function () {
+                var config = new Config({
+                        dimensionsPath: libpath.resolve(fixtures, 'touchdown-simple/configs/dimensions.json'),
+                    }),
+                    fullPath = libpath.resolve(fixtures, 'touchdown-simple/configs/commonjs.cjs');
+                config.addConfigContents('foo', 'bar', fullPath, null, function (err) {
+                    expect(err).to.equal(null);
+                    config.read('foo', 'bar', {}, function (err, have) {
+                        expect(err).to.equal(null);
+                        expect(have).to.deep.equal({
+                            syntax: 'cjs',
+                            transpiled: false,
+                        });
+                    });
+                });
+            });
             it('should work twice in a row', function () {
                 var config,
                     object = { color: 'red' };


### PR DESCRIPTION
I suppose if we support `.mjs` it only makes sense to support `.cjs`. I have a use case where in migrating a project from CJS to ESM it'll be easier to load one config as a CJS module for an unrelated reason.