### PR TITLE
fix: avoid cb exception going to import()

### DIFF
--- a/lib/mod/modern.js
+++ b/lib/mod/modern.js
@@ -14,18 +14,28 @@ module.exports = async (id, callback) => {
     // in this library as it will break anyone using Jest. While there is no way around
     // that for ESM files, we can at least not break CJS by adding a first try to require
     // the file which will then fail over to the ESM compatible import should that fail.
+
+    let cjsMod;
+    let cjsSucceeded = false;
+
     try {
-        const mod = interopDefault(require(id));
-        callback(null, mod);
-        return;
+        cjsMod = interopDefault(require(id));
+        cjsSucceeded = true;
     } catch (e) {
         // do nothing
     }
 
-    try {
-        const mod = interopDefault(await import(id));
-        callback(null, mod.default);
-    } catch (e) {
-        callback(new ParseError(e, id));
+    if (cjsSucceeded) {
+        callback(null, cjsMod);
+    } else {
+        let esmMod;
+
+        try {
+            esmMod = interopDefault(await import(id));
+        } catch (e) {
+            return callback(new ParseError(e, id));
+        }
+
+        callback(null, esmMod.default);
     }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ycb-config",
-    "version": "2.5.0",
+    "version": "2.6.0",
     "description": "Configuration manager for Yahoo configuration bundles",
     "author": "Drew Folta <folta@yahoo-inc.com>",
     "contributors": [],


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

---

Hi, I noticed something in ycb-config, example:
```js
// dimensions.js & config.js are some valid dimension/config files

const ConfigHelper = require('ycb-config');

const helper = new ConfigHelper({ dimensionsPath: __dirname + '/dimensions.js' });
helper.addConfig('config', 'config', __dirname + '/config.js', () => {});

let count = 0;
helper.read('config', 'config', {}, (err, config) => {
    count++;
    console.log(`call cb ${count} time(s)`);

    throw new Error();
});
```
I expect it will print `call cb 1 time(s)` then followed with the unhandled exception thrown in callback, when I run the example in NodeJS.

However, the callback actually gets called three times in total. The actual log result I get is:
```
call cb 1 time(s)
call cb 2 time(s)
call cb 3 time(s)
/Users/ysun01/Temp/ycb-config-example/index.js:12
    throw new Error();
          ^

Error
    at /Users/ysun01/Temp/ycb-config-example/index.js:12:11
    at /Users/ysun01/Temp/ycb-config-example/node_modules/ycb-config/lib/index.js:332:17
    at /Users/ysun01/Temp/ycb-config-example/node_modules/ycb-config/lib/index.js:509:32
    at /Users/ysun01/Temp/ycb-config-example/node_modules/ycb-config/lib/index.js:457:24
    at module.exports (/Users/ysun01/Temp/ycb-config-example/node_modules/ycb-config/lib/mod/modern.js:29:9)

...
```
... since the `try... catch` block in `loadModule` will catch not only `require/import` error but also exception thrown in callback.

I wondered, is it intended? I think it should only fallback to ESM only when the `require` operation fails, excluding fallback fail cases?

Thanks. :)