### PR TITLE
fix: multiple callback

### DIFF
--- a/lib/mod/index.js
+++ b/lib/mod/index.js
@@ -1,4 +1,3 @@
-var path = require('path');
 var version = parseInt(process.versions.node.split('.'), 10);
 var id = version >= 12 ? './modern.js' : './legacy.js';
 

--- a/lib/mod/modern.js
+++ b/lib/mod/modern.js
@@ -1,5 +1,21 @@
 const { interopDefault, ParseError } = require('./utils');
 
+function requireCjs(id) {
+    // Until https://github.com/facebook/jest/issues/9430 is solved, we can't use import
+    // in this library as it will break anyone using Jest. While there is no way around
+    // that for ESM files, we can at least not break CJS by adding a first try to require
+    // the file which will then fail over to the ESM compatible import should that fail.
+    try {
+        return interopDefault(require(id));
+    } catch (e) {
+        // do nothing
+    }
+}
+
+async function importEsm(id) {
+    return interopDefault(await import(id))['default'];
+}
+
 /**
  * Import an ESModule config.
  * @param {String} id module name or path
@@ -10,22 +26,13 @@ const { interopDefault, ParseError } = require('./utils');
  *   JavaScript object.
  */
 module.exports = async (id, callback) => {
-    // Until https://github.com/facebook/jest/issues/9430 is solved, we can't use import
-    // in this library as it will break anyone using Jest. While there is no way around
-    // that for ESM files, we can at least not break CJS by adding a first try to require
-    // the file which will then fail over to the ESM compatible import should that fail.
-    try {
-        const mod = interopDefault(require(id));
-        callback(null, mod);
-        return;
-    } catch (e) {
-        // do nothing
-    }
+    let err, mod;
 
     try {
-        const mod = interopDefault(await import(id));
-        callback(null, mod.default);
+        mod = requireCjs(id) || (await importEsm(id));
     } catch (e) {
-        callback(new ParseError(e, id));
+        err = new ParseError(e, id);
+    } finally {
+        callback(err, mod);
     }
 };

--- a/tests/lib/index.js
+++ b/tests/lib/index.js
@@ -184,6 +184,43 @@ describe('config', function () {
                     expect(have.color).to.equal('red');
                 });
             });
+            it('should callback with error if addConfig fails', function (done) {
+                const fullPath = libpath.resolve(fixtures, 'touchdown-simple/configs/invalid.cjs');
+                const config = new Config({
+                    dimensionsPath: libpath.resolve(fixtures, 'touchdown-simple/configs/dimensions.json'),
+                });
+                const callback = sinon.spy(function () {
+                    throw new Error();
+                });
+
+                config.addConfig('foo', 'bar', fullPath, callback);
+                setImmediate(() => {
+                    expect(callback.callCount).to.equal(1);
+                    const [err, contents] = callback.firstCall.args;
+                    expect(err).to.be.ok;
+                    expect(err.message).to.include('Cannot find module');
+                    expect(contents).to.not.be.ok;
+                    done();
+                });
+            });
+            it('should not call the addConfig callback again the callback itself throws an error', function (done) {
+                const fullPath = libpath.resolve(fixtures, 'touchdown-simple/configs/commonjs.cjs');
+                const config = new Config({
+                    dimensionsPath: libpath.resolve(fixtures, 'touchdown-simple/configs/dimensions.json'),
+                });
+                const callback = sinon.spy(function () {
+                    throw new Error();
+                });
+
+                config.addConfig('foo', 'bar', fullPath, callback);
+                setImmediate(() => {
+                    expect(callback.callCount).to.equal(1);
+                    const [err, contents] = callback.firstCall.args;
+                    expect(err).not.to.be.ok;
+                    expect(contents).to.be.ok;
+                    done();
+                });
+            });
             it('should not set stale ycb', function (done) {
                 var ycbConfig = new Config({
                     dimensionsPath: libpath.resolve(fixtures, 'touchdown-simple/configs/dimensions.json'),


### PR DESCRIPTION
Another spin on https://github.com/yahoo/ycb-config/pull/53

Fixes an issue reported by @wendyyuchensun - if the **addConfig** callback itself throws an error (the original issue mentions read, but the issue has to do with addConfig)

If the require/import fails then we will call the callback (once)
If it succeeds, we will not try/catch any errors which happen in the callback and will not call the callback again.

That being said, the callback itself should try / catch or otherwise handle any errors that might be thrown. YCB will not handle the error here, but if **no one** is handling it, you may have issues.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
